### PR TITLE
Make sure we run the Firefox binary from TBB

### DIFF
--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -48,6 +48,7 @@ class TorBrowserDriver(FirefoxDriver):
         self.update_prefs(pref_dict)
         self.setup_capabilities()
         self.export_lib_path()
+        self.export_path()
         self.binary = self.get_tbb_binary(logfile=tbb_logfile_path)
         super(TorBrowserDriver, self).__init__(firefox_profile=self.profile,
                                                firefox_binary=self.binary,
@@ -173,6 +174,16 @@ class TorBrowserDriver(FirefoxDriver):
                                           cm.DEFAULT_FONTCONFIG_PATH)
         environ["FONTCONFIG_FILE"] = cm.FONTCONFIG_FILE
         environ["HOME"] = tbb_browser_dir
+
+    def export_path(self):
+        """Setup PATH environment variable."""
+        tbb_root_dir = dirname(dirname(self.tbb_fx_binary_path))
+        tbb_browser_dir = join(tbb_root_dir, cm.DEFAULT_TBB_BROWSER_DIR)
+
+        # Add "TBB_DIR/Browser" to the PATH
+        current_path = environ["PATH"]
+        environ["PATH"] = "%s:%s" % (tbb_browser_dir,
+                                                current_path)
 
     def setup_capabilities(self):
         """Setup the required webdriver capabilities."""

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -248,6 +248,9 @@ class TBDriverOptionalArgs(unittest.TestCase):
         self.assertEqual(used_font_files, bundled_font_files)
         environ["FC_DEBUG"] = ""
 
+    def test_correct_firefox_binary(self):
+        with TorBrowserDriver(TBB_PATH) as driver:
+            self.assertTrue(driver.binary.which('firefox').startswith(TBB_PATH))
 
 class TBDriverTestAssumptions(unittest.TestCase):
     """Tests for some assumptions we use in the above tests."""


### PR DESCRIPTION
As of today, the [Firefox Webdriver](https://github.com/SeleniumHQ/selenium/blob/194d041e97904fe023f5c03967c7a5dc70310d89/py/selenium/webdriver/firefox/webdriver.py#L67) of Selenium tries to find the
location of the [Firefox binary](https://github.com/SeleniumHQ/selenium/blob/194d041e97904fe023f5c03967c7a5dc70310d89/py/selenium/webdriver/firefox/firefox_binary.py#L157) [in the PATH environment variable of
Linux](https://github.com/SeleniumHQ/selenium/blob/194d041e97904fe023f5c03967c7a5dc70310d89/py/selenium/webdriver/firefox/firefox_binary.py#L202).

Modifying the PATH environment variable, we ensure we use the firefox
binary from the Tor Browser Bundle, avoiding possible problems in the
future once we introduce Marionette tests.