### PR TITLE
Add a test to make sure we load the Firefox libraries from TBB dirs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 install:
   - sudo apt-get -qq install tor
-  - sudo pip install stem
+  - sudo -H pip install stem
   - easy_install .
   - wget https://archive.torproject.org/tor-package-archive/torbrowser/5.5.4/tor-browser-linux64-5.5.4_en-US.tar.xz
   - tar -xvf tor-browser-linux64-5.5.4_en-US.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 install:
   - sudo apt-get -qq install tor
+  - sudo pip install stem
   - easy_install .
   - wget https://archive.torproject.org/tor-package-archive/torbrowser/5.5.4/tor-browser-linux64-5.5.4_en-US.tar.xz
   - tar -xvf tor-browser-linux64-5.5.4_en-US.tar.xz

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -78,10 +78,11 @@ class TBDriverTest(unittest.TestCase):
 
         We only test libxul (main Firefox/Gecko library) and libstdc++.
         """
-        xul_lib_path = join(self.tb_driver.tbb_browser_dir, "libxul.so")
-        std_c_lib_path = join(self.tb_driver.tbb_path,
-                              cm.DEFAULT_TOR_BINARY_DIR,
-                              "libstdc++.so.6")
+        xul_lib_path = abspath(join(self.tb_driver.tbb_browser_dir,
+                                    "libxul.so"))
+        std_c_lib_path = abspath(join(self.tb_driver.tbb_path,
+                                      cm.DEFAULT_TOR_BINARY_DIR,
+                                      "libstdc++.so.6"))
 
         self.failUnless(self.tb_driver.binary.process,
                         "TorBrowserDriver process doesn't exist")

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -52,13 +52,13 @@ class TBDriverTest(unittest.TestCase):
         """Visiting a site should not modify the original profile contents."""
         profile_path = join(TBB_PATH, cm.DEFAULT_TBB_PROFILE_PATH)
         profile_hash_before = ut.get_hash_of_directory(profile_path)
-        self.tb_driver.get(cm.CHECK_TPO_URL)
+        self.tb_driver.load_url_ensure(cm.CHECK_TPO_URL)
         profile_hash_after = ut.get_hash_of_directory(profile_path)
         self.assertEqual(profile_hash_before, profile_hash_after)
 
     def test_httpseverywhere(self):
         """HTTPSEverywhere should redirect to HTTPS version."""
-        self.tb_driver.get(TEST_HTTP_URL)
+        self.tb_driver.load_url_ensure(TEST_HTTP_URL)
         try:
             WebDriverWait(self.tb_driver, TEST_LONG_WAIT).\
                 until(EC.title_contains("thanks"))
@@ -218,8 +218,9 @@ class TBDriverOptionalArgs(unittest.TestCase):
         try:
             from stem.control import Controller
             from stem.process import launch_tor_with_config
-        except ImportError:
-            print("Skipping Stem test. Install stem to run this test.")
+        except ImportError as err:
+            print("Skipping Stem test. Install stem to run this test: %s" %
+                  err)
             return
         custom_tor_binary = join(TBB_PATH, cm.DEFAULT_TOR_BINARY_PATH)
         environ["LD_LIBRARY_PATH"] = dirname(custom_tor_binary)

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 import re
 from os import remove, environ
-from os.path import getsize, exists, join, abspath, dirname
+from os.path import getsize, exists, join, abspath, dirname, isfile, basename
 
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions as EC
@@ -72,6 +72,42 @@ class TBDriverTest(unittest.TestCase):
                                        wait_for_page_body=True)
         webgl_support = self.tb_driver.execute_script(WEBGL_CHECK_JS)
         self.assertIsNone(webgl_support)
+
+    def test_should_load_tbb_firefox_libs(self):
+        """Make sure we load the Firefox libraries from the TBB directories.
+
+        We only test libxul (main Firefox/Gecko library) and libstdc++.
+        """
+        xul_lib_path = join(self.tb_driver.tbb_browser_dir, "libxul.so")
+        std_c_lib_path = join(self.tb_driver.tbb_path,
+                              cm.DEFAULT_TOR_BINARY_DIR,
+                              "libstdc++.so.6")
+
+        self.failUnless(self.tb_driver.binary.process,
+                        "TorBrowserDriver process doesn't exist")
+        pid = self.tb_driver.binary.process.pid
+
+        for lib_path in [xul_lib_path, std_c_lib_path]:
+            lib_loaded_from_tbb = False
+            self.failUnless(isfile(lib_path),
+                            "Can't find the library %s" % lib_path)
+            lib_name = basename(lib_path)
+            lib_escaped = lib_name.replace(".", "\.")  # to use with grep
+
+            cmd = "lsof -p %d | awk '{print $9}' | grep '%s'"\
+                % (pid, lib_escaped)
+            status, out = ut.run_cmd(cmd)
+            self.assertFalse(int(status),
+                             "Error running command: %s\nStatus: %s\nOut: %s" %
+                             (cmd, status, out))
+            for out_line in out.split("\n"):
+                if lib_name in out_line:  # remove potential lsof warning msgs
+                    if lib_path == out_line:
+                        lib_loaded_from_tbb = True
+
+            self.assertTrue(lib_loaded_from_tbb,
+                            "Can't find the loaded lib: %s\nCmd output: %s" %
+                            (xul_lib_path, out))
 
 
 class TBDriverFailTest(unittest.TestCase):
@@ -293,6 +329,7 @@ class TBDriverOptionalArgs(unittest.TestCase):
     def test_correct_firefox_binary(self):
         with TorBrowserDriver(TBB_PATH) as driver:
             self.assertTrue(driver.binary.which('firefox').startswith(TBB_PATH))
+
 
 class TBDriverTestAssumptions(unittest.TestCase):
     """Tests for some assumptions we use in the above tests."""


### PR DESCRIPTION
We use lsof to get libraries loaded by TB and make sure that
libxul.so and libstdc++.so.6 are loaded from TBB dirs.

Fixes #16.