### PR TITLE
Add an argument to specify the tor data directory.

### DIFF
--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -28,11 +28,13 @@ class TorBrowserDriver(FirefoxDriver):
                  tbb_fx_binary_path="",
                  tbb_profile_path="",
                  tbb_logfile_path="",
+                 tor_data_dir="",
                  pref_dict={},
                  socks_port=None,
                  virt_display=cm.DEFAULT_XVFB_WINDOW_SIZE,
                  canvas_exceptions=[]):
 
+        self.tor_data_dir = tor_data_dir  # only relevant if we launch tor
         self.setup_tbb_paths(tbb_path, tbb_fx_binary_path, tbb_profile_path)
         self.tor_cfg = tor_cfg
         self.canvas_exceptions = [get_tld(url) for url in canvas_exceptions]
@@ -152,6 +154,8 @@ class TorBrowserDriver(FirefoxDriver):
         set_pref('extensions.torlauncher.control_port', self.socks_port+1)
         if self.tor_cfg == cm.LAUNCH_NEW_TBB_TOR:
             set_pref('extensions.torlauncher.start_tor', True)
+            set_pref('extensions.torlauncher.tordatadir_path',
+                     self.tor_data_dir)
         else:  # Prevent Tor Browser running its own Tor process
             # start-tor-browser script suggests that "if using a
             # system-installed Tor, the following about:config options should

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -330,7 +330,29 @@ class TBDriverOptionalArgs(unittest.TestCase):
 
     def test_correct_firefox_binary(self):
         with TorBrowserDriver(TBB_PATH) as driver:
-            self.assertTrue(driver.binary.which('firefox').startswith(TBB_PATH))
+            self.assertTrue(driver.binary.which('firefox').
+                            startswith(TBB_PATH))
+
+    def test_temp_tor_data_dir(self):
+        """If we use a temporary directory as tor_data_dir,
+        tor datadir in TBB should stay unchanged.
+        """
+        tmp_dir = tempfile.mkdtemp()
+        tbb_tor_data_path = join(TBB_PATH, cm.DEFAULT_TOR_DATA_PATH)
+        hash_before = ut.get_hash_of_directory(tbb_tor_data_path)
+        with TorBrowserDriver(TBB_PATH, tor_data_dir=tmp_dir) as driver:
+            driver.load_url_ensure(cm.CHECK_TPO_URL)
+        hash_after = ut.get_hash_of_directory(tbb_tor_data_path)
+        self.assertEqual(hash_before, hash_after)
+
+    def test_non_temp_tor_data_dir(self):
+        """Tor data dir in TBB should change if we don't use tor_data_dir."""
+        tbb_tor_data_path = join(TBB_PATH, cm.DEFAULT_TOR_DATA_PATH)
+        hash_before = ut.get_hash_of_directory(tbb_tor_data_path)
+        with TorBrowserDriver(TBB_PATH) as driver:
+            driver.load_url_ensure(cm.CHECK_TPO_URL)
+        hash_after = ut.get_hash_of_directory(tbb_tor_data_path)
+        self.assertNotEqual(hash_before, hash_after)
 
 
 class TBDriverTestAssumptions(unittest.TestCase):


### PR DESCRIPTION
This argument is only used if we launch a new process.
Add tests to make sure when we specify a temporary datadir,
TBB's data dir stay unchanged.

Fixes issue #5 