### PR TITLE
Better handle custom ports (issue #8)

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -3,7 +3,8 @@ import sys
 from subprocess import call
 from os import environ
 from os.path import isdir, realpath, dirname, join
-
+# TODO: Do we still need this module or can we do all of that with py.test
+# Alternatively we can call py.test from this module
 # Validate input
 if len(sys.argv) != 2:
     print "ERROR: the path to the Tor Browser Bundle directory is a required argument."

--- a/tbselenium/common.py
+++ b/tbselenium/common.py
@@ -42,3 +42,7 @@ USE_RUNNING_TOR = 1  # use the tor installed and running on the system
 
 class TBDriverPathError(Exception):
     pass
+
+
+class TBDriverPortError(Exception):
+    pass

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -1,7 +1,7 @@
 import shutil
 from httplib import CannotSendRequest
 from os import environ, chdir
-from os.path import isdir, isfile, join
+from os.path import isdir, isfile, join, abspath
 from time import sleep
 from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
@@ -97,7 +97,8 @@ class TorBrowserDriver(FirefoxDriver):
         if tor_data_dir:
             self.tor_data_dir = tor_data_dir  # only relevant if we launch tor
         else:
-            self.tor_data_dir = join(tbb_path, cm.DEFAULT_TOR_DATA_PATH)
+            self.tor_data_dir = abspath(join(tbb_path,
+                                             cm.DEFAULT_TOR_DATA_PATH))
 
         # TB can't find bundled "fonts" if we don't switch to tbb_browser_dir
         chdir(self.tbb_browser_dir)

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -3,7 +3,6 @@ from httplib import CannotSendRequest
 from os import environ, chdir
 from os.path import isdir, isfile, join
 from time import sleep
-
 from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -14,7 +13,7 @@ from selenium.webdriver.firefox.webdriver import WebDriver as FirefoxDriver
 from tld import get_tld
 
 import common as cm
-from utils import add_canvas_permission
+from tbselenium.utils import add_canvas_permission
 from selenium.common.exceptions import TimeoutException
 
 
@@ -33,18 +32,28 @@ class TorBrowserDriver(FirefoxDriver):
                  socks_port=None,
                  canvas_exceptions=[]):
 
-        self.tor_data_dir = tor_data_dir  # only relevant if we launch tor
-        self.setup_tbb_paths(tbb_path, tbb_fx_binary_path, tbb_profile_path)
         self.tor_cfg = tor_cfg
+        self.setup_tbb_paths(tbb_path, tbb_fx_binary_path,
+                             tbb_profile_path, tor_data_dir)
         self.canvas_exceptions = [get_tld(url) for url in canvas_exceptions]
         self.profile = webdriver.FirefoxProfile(self.tbb_profile_path)
         add_canvas_permission(self.profile.path, self.canvas_exceptions)
         if socks_port is None:
-            if tor_cfg == cm.USE_RUNNING_TOR:  # 9050 if port isn't specified
-                socks_port = cm.DEFAULT_SOCKS_PORT
+            if tor_cfg == cm.USE_RUNNING_TOR:
+                socks_port = cm.DEFAULT_SOCKS_PORT  # 9050
             else:
                 socks_port = cm.TBB_SOCKS_PORT  # 9150
         self.socks_port = socks_port
+        if tor_cfg == cm.LAUNCH_NEW_TBB_TOR and\
+                socks_port != cm.TBB_SOCKS_PORT:
+            # No support for launching TBB's Tor on a custom port
+            # Managing/editing torrc would be messy
+            # TorBrowserDriver can connect to a running Tor process on any port
+            # This is limitation is about launching Tor.
+            # You can use Stem to launch Tor on the port you like and have
+            # TorBrowserDriver connect to it.
+            raise cm.TBDriverPortError("Error: Use Stem if you need to launch"
+                                       " Tor on a custom SOCKS port")
         self.update_prefs(pref_dict)
         self.setup_capabilities()
         self.export_env_vars()
@@ -56,7 +65,8 @@ class TorBrowserDriver(FirefoxDriver):
                                                timeout=60)
         self.is_running = True
 
-    def setup_tbb_paths(self, tbb_path, tbb_fx_binary_path, tbb_profile_path):
+    def setup_tbb_paths(self, tbb_path, tbb_fx_binary_path, tbb_profile_path,
+                        tor_data_dir):
         """Update instance variables based on the passed paths.
 
         TorBrowserDriver can be initialized by passing either
@@ -84,6 +94,11 @@ class TorBrowserDriver(FirefoxDriver):
         self.tbb_profile_path = tbb_profile_path
         self.tbb_fx_binary_path = tbb_fx_binary_path
         self.tbb_browser_dir = join(tbb_path, cm.DEFAULT_TBB_BROWSER_DIR)
+        if tor_data_dir:
+            self.tor_data_dir = tor_data_dir  # only relevant if we launch tor
+        else:
+            self.tor_data_dir = join(tbb_path, cm.DEFAULT_TOR_DATA_PATH)
+
         # TB can't find bundled "fonts" if we don't switch to tbb_browser_dir
         chdir(self.tbb_browser_dir)
 

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -157,6 +157,11 @@ class TBDriverFailTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             TorBrowserDriver(TBB_PATH, pref_dict=(1, 2))
 
+    def test_should_fail_launching_tor_on_custom_socks_port(self):
+        with self.assertRaises(cm.TBDriverPortError):
+            TorBrowserDriver(TBB_PATH, socks_port=10001,
+                             tor_cfg=cm.LAUNCH_NEW_TBB_TOR)
+
     def test_should_fail_with_wrong_sys_socks_port(self):
         with TorBrowserDriver(TBB_PATH, socks_port=9999,
                               tor_cfg=cm.USE_RUNNING_TOR) as driver:
@@ -228,9 +233,9 @@ class TBDriverOptionalArgs(unittest.TestCase):
             return
         custom_tor_binary = join(TBB_PATH, cm.DEFAULT_TOR_BINARY_PATH)
         environ["LD_LIBRARY_PATH"] = dirname(custom_tor_binary)
-        # any port number would do, pick 9250 to avoid conflict
-        socks_port = cm.TBB_SOCKS_PORT
-        control_port = cm.TBB_CONTROL_PORT
+        # any port would do, pick 9250, 9251 to avoid conflict
+        socks_port = 9250
+        control_port = 9251
         temp_data_dir = tempfile.mkdtemp()
         torrc = {'ControlPort': str(control_port),
                  'SOCKSPort': str(socks_port),

--- a/tbselenium/utils.py
+++ b/tbselenium/utils.py
@@ -1,24 +1,21 @@
 import commands
 import sqlite3
-from os import walk, makedirs
-from os.path import join, exists
+from os import walk
+from os.path import join
 import fnmatch
+from hashlib import sha256
 
 
-def get_hash_of_directory(path):
-    """Return md5 hash of the directory pointed by path."""
-    from hashlib import md5
-    m = md5()
-    for root, _, files in walk(path):
-        for f in files:
-            full_path = join(root, f)
-            for line in open(full_path).readlines():
-                m.update(line)
+def get_hash_of_directory(dir_path):
+    """Return sha256 hash of the directory pointed by path."""
+    m = sha256()
+    for file_path in gen_find_files(dir_path):
+        m.update(read_file(file_path))
     return m.digest()
 
 
 def gen_find_files(dir_path, pattern="*"):
-    """Returns filenames that matches the given pattern under a given dir
+    """Return filenames that matches the given pattern under a given dir
     http://www.dabeaz.com/generators/
     """
     for path, _, filelist in walk(dir_path):
@@ -26,9 +23,9 @@ def gen_find_files(dir_path, pattern="*"):
             yield join(path, name)
 
 
-def read_file(path, mode='rU'):
+def read_file(file_path, mode='rU'):
     """Read and return file content."""
-    with open(path, mode) as f:
+    with open(file_path, mode) as f:
         content = f.read()
     return content
 


### PR DESCRIPTION
Better handle non-default SOCKS ports.

Raise an exception if the caller wants us to launch a Tor process
on a custom (!=9150) port.

Refactor utils module. Use SHA-256 instead of MD5.

Run Stem test on a different SOCKS port (9250).