### PR TITLE
Remove pyvirtualdisplay from setup py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     packages=["tbselenium"],
     install_requires=[
         "selenium >= 2.45.0",
-        "tld",
-        "pyvirtualdisplay"
+        "tld"
     ]
 )

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -125,7 +125,7 @@ class TorBrowserDriver(FirefoxDriver):
                         max_reload_tries=5):
         """Make sure the requested URL is loaded. Retry if necessary."""
         last_err = None
-        for tries in range(1, max_reload_tries+1):
+        for tries in range(1, max_reload_tries + 1):
             try:
                 self.load_url(url, wait_on_page, wait_for_page_body)
                 if tries > 1:  # TODO:  for debugging, can be removed
@@ -167,7 +167,7 @@ class TorBrowserDriver(FirefoxDriver):
                                    socks_port,
                                    control_port))
 
-    def set_tb_prefs_for_using_system_tor(self):
+    def set_tb_prefs_for_using_system_tor(self, control_port):
         """Set the preferences suggested by start-tor-browser script
         to run TB with system-installed Tor.
 
@@ -186,7 +186,7 @@ class TorBrowserDriver(FirefoxDriver):
         set_pref('extensions.torbutton.logmethod', 0)
         set_pref('extensions.torbutton.settings_method', 'custom')
         set_pref('extensions.torbutton.use_privoxy', False)
-        set_pref('extensions.torlauncher.control_port', self.socks_port+1)
+        set_pref('extensions.torlauncher.control_port', control_port)
         set_pref('extensions.torlauncher.loglevel', 2)
         set_pref('extensions.torlauncher.logmethod', 0)
         set_pref('extensions.torlauncher.prompt_at_startup', False)
@@ -215,7 +215,7 @@ class TorBrowserDriver(FirefoxDriver):
             set_pref('extensions.torlauncher.tordatadir_path',
                      self.tor_data_dir)
         else:
-            self.set_tb_prefs_for_using_system_tor()
+            self.set_tb_prefs_for_using_system_tor(control_port)
         # pref_dict overwrites above preferences
         for pref_name, pref_val in pref_dict.iteritems():
             set_pref(pref_name, pref_val)

--- a/tbselenium/test/conftest.py
+++ b/tbselenium/test/conftest.py
@@ -1,6 +1,10 @@
 import pytest
-from pyvirtualdisplay import Display
 from os import environ
+try:
+    from pyvirtualdisplay import Display
+except ImportError:  # we don't need/install it when running CI tests
+    pass
+
 # Default size for the virtual display
 DEFAULT_XVFB_WIN_W = 1280
 DEFAULT_XVFB_WIN_H = 800


### PR DESCRIPTION
We don't depend on pyvirtualdisplay, except when running tests locally.

We should mention this "developer dependency" in the README.md to
make sure that people install pyvirtualdisplay if they want to run tests
with XVFB..