### PR TITLE
Convert all the TBB related paths to absolute paths during init

### DIFF
--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -90,15 +90,17 @@ class TorBrowserDriver(FirefoxDriver):
         if not isdir(tbb_profile_path):
             raise cm.TBDriverPathError("Invalid Firefox profile dir %s"
                                        % tbb_profile_path)
-        self.tbb_path = tbb_path
-        self.tbb_profile_path = tbb_profile_path
-        self.tbb_fx_binary_path = tbb_fx_binary_path
+        # Convert all the paths to absolute. We set Fx prefs and env. vars
+        # based on these paths (e.g. tor_data_dir, FONTCONFIG_PATH), which
+        # won't work if paths are relative.
+        self.tbb_path = abspath(tbb_path)
+        self.tbb_profile_path = abspath(tbb_profile_path)
+        self.tbb_fx_binary_path = abspath(tbb_fx_binary_path)
         self.tbb_browser_dir = join(tbb_path, cm.DEFAULT_TBB_BROWSER_DIR)
         if tor_data_dir:
             self.tor_data_dir = tor_data_dir  # only relevant if we launch tor
         else:
-            self.tor_data_dir = abspath(join(tbb_path,
-                                             cm.DEFAULT_TOR_DATA_PATH))
+            self.tor_data_dir = join(tbb_path, cm.DEFAULT_TOR_DATA_PATH)
 
         # TB can't find bundled "fonts" if we don't switch to tbb_browser_dir
         chdir(self.tbb_browser_dir)

--- a/tbselenium/test/__init__.py
+++ b/tbselenium/test/__init__.py
@@ -1,5 +1,9 @@
 # Environment variable that points to TBB directory:
 from os import environ
-TBB_PATH = environ.get('TBB_PATH')
+from os.path import abspath, isdir
+
+TBB_PATH = abspath(environ.get('TBB_PATH'))
 if TBB_PATH is None:
-    raise RuntimeError("Environment variable `TBB_PATH` with TBB directory not found.")
+    raise RuntimeError("Environment variable `TBB_PATH` cannot be found.")
+elif not isdir(TBB_PATH):
+    raise RuntimeError("`TBB_PATH` is not a directory.")

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 import re
 from os import remove, environ
-from os.path import getsize, exists, join, abspath, dirname, isfile, basename
+from os.path import getsize, exists, join, dirname, isfile, basename
 
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions as EC
@@ -81,11 +81,10 @@ class TBDriverTest(unittest.TestCase):
         """Make sure we load the Firefox libraries from the TBB directories.
         We only test libxul (main Firefox/Gecko library) and libstdc++.
         """
-        xul_lib_path = abspath(join(self.tb_driver.tbb_browser_dir,
-                                    "libxul.so"))
-        std_c_lib_path = abspath(join(self.tb_driver.tbb_path,
-                                      cm.DEFAULT_TOR_BINARY_DIR,
-                                      "libstdc++.so.6"))
+        xul_lib_path = join(self.tb_driver.tbb_browser_dir, "libxul.so")
+        std_c_lib_path = join(self.tb_driver.tbb_path,
+                              cm.DEFAULT_TOR_BINARY_DIR,
+                              "libstdc++.so.6")
 
         self.failUnless(self.tb_driver.binary.process,
                         "TorBrowserDriver process doesn't exist")
@@ -299,8 +298,7 @@ class TBDriverOptionalArgs(unittest.TestCase):
         _, log_file = tempfile.mkstemp()
         used_font_files = set()
         bundled_fonts_dir = join(TBB_PATH, cm.DEFAULT_BUNDLED_FONTS_PATH)
-        # join returns a relative path on Travis CI
-        bundled_fonts_dir = abspath(bundled_fonts_dir)
+        bundled_fonts_dir = bundled_fonts_dir
         environ["FC_DEBUG"] = "%d" % (1024 + 8 + 1)
         """
         We set FC_DEBUG to 1024 + 8 + 1 to make sure we get logs about...


### PR DESCRIPTION
We ran into issue with relative during CI tests, where TBB_PATH is supplied
as a relative path. Now we convert the paths as early as possible
during the initialization of TorBrowserDriver and in __init__.py
where we read TBB_PATH from the environment variable.
Fixes #27 