### PR TITLE
Remote tld dependency, rename canvas_exceptions to canvas_allowed_hosts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(
     version=1.0,
     packages=["tbselenium"],
     install_requires=[
-        "selenium >= 2.45.0",
-        "tld"
+        "selenium >= 2.45.0"
     ]
 )

--- a/tbselenium/common.py
+++ b/tbselenium/common.py
@@ -32,6 +32,7 @@ STREAM_CLOSE_TIMEOUT = 20  # wait 20 seconds before raising an alarm signal
 
 # Test constants
 CHECK_TPO_URL = "http://check.torproject.org"
+CHECK_TPO_HOST = "check.torproject.org"
 TEST_URL = CHECK_TPO_URL
 ABOUT_TOR_URL = "about:tor"
 

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -10,7 +10,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.webdriver import WebDriver as FirefoxDriver
-from tld import get_tld
 
 import common as cm
 from tbselenium.utils import add_canvas_permission
@@ -30,14 +29,14 @@ class TorBrowserDriver(FirefoxDriver):
                  tor_data_dir="",
                  pref_dict={},
                  socks_port=None,
-                 canvas_exceptions=[]):
+                 canvas_allowed_hosts=[]):
 
         self.tor_cfg = tor_cfg
         self.setup_tbb_paths(tbb_path, tbb_fx_binary_path,
                              tbb_profile_path, tor_data_dir)
-        self.canvas_exceptions = [get_tld(url) for url in canvas_exceptions]
+        self.canvas_allowed_hosts = canvas_allowed_hosts
         self.profile = webdriver.FirefoxProfile(self.tbb_profile_path)
-        add_canvas_permission(self.profile.path, self.canvas_exceptions)
+        add_canvas_permission(self.profile.path, self.canvas_allowed_hosts)
         if socks_port is None:
             if tor_cfg == cm.USE_RUNNING_TOR:
                 socks_port = cm.DEFAULT_SOCKS_PORT  # 9050

--- a/tbselenium/test/test_env.py
+++ b/tbselenium/test/test_env.py
@@ -44,9 +44,6 @@ class EnvironmentTest(unittest.TestCase):
                         """No process is listening on SOCKS port %s!""" %
                         cm.DEFAULT_SOCKS_PORT)
 
-    def test_tld(self):
-        self.assert_py_pkg_installed('tld')
-
     def test_selenium(self):
         self.assert_py_pkg_installed('selenium')
 

--- a/tbselenium/test/test_examples.py
+++ b/tbselenium/test/test_examples.py
@@ -30,8 +30,9 @@ class TorBrowserDriverExamples(unittest.TestCase):
         # We need to add an exception for canvas access in the Tor Browser
         # permission database. We need to do this for each site that we
         # plan to visit.
+        canvas_allowed = [cm.CHECK_TPO_HOST]
         with TorBrowserDriver(TBB_PATH,
-                              canvas_exceptions=[cm.TEST_URL]) as driver:
+                              canvas_allowed_hosts=canvas_allowed) as driver:
             driver.get(cm.TEST_URL)
             driver.get_screenshot_as_file("screenshot.png")
 

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -13,7 +13,6 @@ from tbselenium import common as cm
 from tbselenium.tbdriver import TorBrowserDriver
 from tbselenium.test import TBB_PATH
 import tbselenium.utils as ut
-from tld.exceptions import TldBadUrl
 
 TEST_LONG_WAIT = 60
 
@@ -167,14 +166,6 @@ class TBDriverFailTest(unittest.TestCase):
             driver.load_url(cm.CHECK_TPO_URL)
             self.assertEqual(driver.title, "Problem loading page")
 
-    def test_should_raise_for_invalid_canvas_exceptions(self):
-        with self.assertRaises(TldBadUrl):
-            TorBrowserDriver(TBB_PATH, canvas_exceptions=["foo", "bar"])
-        with self.assertRaises(TldBadUrl):
-            TorBrowserDriver(TBB_PATH, canvas_exceptions=["foo.bar"])
-        with self.assertRaises(AttributeError):
-            TorBrowserDriver(TBB_PATH, canvas_exceptions=[1, 2])
-
 
 class ScreenshotTest(unittest.TestCase):
     def setUp(self):
@@ -185,10 +176,12 @@ class ScreenshotTest(unittest.TestCase):
             remove(self.temp_file)
 
     def test_screen_capture(self):
-        """Make sure we can capture the screen."""
+        """Make sure we can capture the screen.
+        Passing canvas_allowed_hosts is not needed for TBB >= 4.5a3
+        """
+        canvas_allowed = [cm.CHECK_TPO_HOST]
         with TorBrowserDriver(TBB_PATH,
-                              canvas_exceptions=[cm.CHECK_TPO_URL]) as driver:
-            # passing canvas_exceptions is not needed for TBB >= 4.5a3
+                              canvas_allowed_hosts=canvas_allowed) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL, 3)
             driver.get_screenshot_as_file(self.temp_file)
         # A blank image for https://check.torproject.org/ amounts to ~4.8KB.

--- a/tbselenium/test/test_utils.py
+++ b/tbselenium/test/test_utils.py
@@ -2,7 +2,6 @@ import tempfile
 import unittest
 from os import makedirs
 from os.path import join
-from tld import get_tld
 import tbselenium.utils as ut
 
 
@@ -27,18 +26,6 @@ class UtilsTest(unittest.TestCase):
             f.write('\0')
         hash_after = ut.get_hash_of_directory(temp_dir)
         self.assertNotEqual(hash_before, hash_after)
-
-    def test_get_public_suffix(self):
-        """Make sure we get the right domain for all the edge cases."""
-        urls = ('http://www.foo.org',
-                'https://www.foo.org',
-                'http://www.subdomain.foo.org',
-                'http://www.subdomain.foo.org:80/subfolder',
-                'https://www.subdomain.foo.org:80/subfolder?p1=4545&p2=54545',
-                'https://www.subdomain.foo.org:80/subfolder/baefasd==/65')
-        for pub_suf_test_url in urls:
-            self.assertEqual(get_tld(pub_suf_test_url), "foo.org")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tbselenium/utils.py
+++ b/tbselenium/utils.py
@@ -46,7 +46,7 @@ def is_port_listening(port_no):
     return "LISTEN" in output
 
 
-def add_canvas_permission(profile_path, canvas_exceptions):
+def add_canvas_permission(profile_path, canvas_allowed_hosts):
     """Create a permission db (permissions.sqlite) and add
     exceptions for the canvas image extraction for the given domains.
     If we don't add permissions, screenshots taken by TBB < 4.5a3 will be
@@ -76,9 +76,9 @@ def add_canvas_permission(profile_path, canvas_exceptions):
       expireTime INTEGER,
       appId INTEGER,
       isInBrowserElement INTEGER)""")
-    for domain in canvas_exceptions:
+    for host in canvas_allowed_hosts:
         qry = """INSERT INTO 'moz_hosts'
-        VALUES(NULL,'%s','canvas/extractData',1,0,0,0,0);""" % domain
+        VALUES(NULL,'%s','canvas/extractData',1,0,0,0,0);""" % host
         cursor.execute(qry)
     perm_db.commit()
     cursor.close()


### PR DESCRIPTION
Dependency for tld package was only needed to get TLD+1 for URLs exempt
from canvas defense. Yet, we don't need the canvas_exceptions for
TBB >= 4.5a3 and we can expect the caller to pass allowed hosts
instead of URLs if they need to use TorBrowserDriver with outdated TB
versions.

We rename the argument canvas_exceptions to canvas_allowed_hosts to
signal the change.