### PR TITLE
Issue24 remove deprecated command module

### DIFF
--- a/tbselenium/test/test_env.py
+++ b/tbselenium/test/test_env.py
@@ -1,6 +1,7 @@
-from tbselenium.utils import is_port_listening, run_cmd
 import unittest
+from selenium.webdriver.common.utils import is_connectable
 from tbselenium import common as cm
+from tbselenium.utils import run_cmd
 
 
 class EnvironmentTest(unittest.TestCase):
@@ -40,7 +41,7 @@ class EnvironmentTest(unittest.TestCase):
     @unittest.skip("We no longer depend on system tor")
     def test_default_tor_ports(self):
         """Make sure tor is listening on the port we expect."""
-        self.assertTrue(is_port_listening(cm.DEFAULT_SOCKS_PORT),
+        self.assertTrue(is_connectable(cm.DEFAULT_SOCKS_PORT),
                         """No process is listening on SOCKS port %s!""" %
                         cm.DEFAULT_SOCKS_PORT)
 

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -8,6 +8,7 @@ from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.utils import is_connectable
 
 from tbselenium import common as cm
 from tbselenium.tbdriver import TorBrowserDriver
@@ -207,7 +208,7 @@ class TBDriverOptionalArgs(unittest.TestCase):
         """Make sure we can run using the tor running on the system.
         This test requires a system tor process with SOCKS port 9050.
         """
-        if not ut.is_port_listening(cm.DEFAULT_SOCKS_PORT):
+        if not is_connectable(cm.DEFAULT_SOCKS_PORT):
             print("Skipping system tor test. Start tor to run this test.")
             return
         with TorBrowserDriver(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR) as driver:

--- a/tbselenium/utils.py
+++ b/tbselenium/utils.py
@@ -1,9 +1,24 @@
-import commands
+from subprocess import STDOUT, check_output, CalledProcessError
 import sqlite3
 from os import walk
 from os.path import join
 import fnmatch
 from hashlib import sha256
+try:
+    from subprocess import getstatusoutput  # added in Python 3
+except ImportError:
+    # Taken from https://hg.python.org/cpython/file/3.4/Lib/subprocess.py#l694
+    def getstatusoutput(cmd):
+        try:
+            data = check_output(cmd, shell=True, universal_newlines=True,
+                                stderr=STDOUT)
+            status = 0
+        except CalledProcessError as ex:
+            data = ex.output
+            status = ex.returncode
+        if data[-1:] == '\n':
+            data = data[:-1]
+        return status, data
 
 
 def get_hash_of_directory(dir_path):
@@ -37,7 +52,7 @@ def is_png(path):
 
 
 def run_cmd(cmd):
-    return commands.getstatusoutput('%s ' % cmd)
+    return getstatusoutput('%s ' % cmd)
 
 
 def add_canvas_permission(profile_path, canvas_allowed_hosts):

--- a/tbselenium/utils.py
+++ b/tbselenium/utils.py
@@ -40,12 +40,6 @@ def run_cmd(cmd):
     return commands.getstatusoutput('%s ' % cmd)
 
 
-def is_port_listening(port_no):
-    cmd = "netstat -atn | grep %s" % port_no
-    _, output = run_cmd(cmd)
-    return "LISTEN" in output
-
-
 def add_canvas_permission(profile_path, canvas_allowed_hosts):
     """Create a permission db (permissions.sqlite) and add
     exceptions for the canvas image extraction for the given domains.


### PR DESCRIPTION
Remove dependency to deprecated commands module.
Use subprocess.getstatusoutput as it is implemented in Python 3.

Remove is_port_listening function which depends on run_cmd.
Now we use is_connectable from selenium.


Fixes #24 