### PR TITLE
Avoid running shell commands.

### DIFF
--- a/tbselenium/test/test_env.py
+++ b/tbselenium/test/test_env.py
@@ -1,7 +1,8 @@
+import pytest
 import unittest
+from os import environ
 from selenium.webdriver.common.utils import is_connectable
 from tbselenium import common as cm
-from tbselenium.utils import run_cmd
 
 
 class EnvironmentTest(unittest.TestCase):
@@ -12,38 +13,10 @@ class EnvironmentTest(unittest.TestCase):
             self.fail("Missing python package. Install it by running"
                       " '(sudo) pip install %s'" % pkg_name)
 
-    def assert_installed(self, pkg_name):
-        cmd = 'which %s' % pkg_name
-        status, _ = self.run_cmd(cmd)
-        self.assertFalse(status,
-                         "%s is not installed. \
-                         Install it by running '(sudo) apt-get install %s'" %
-                         (pkg_name, pkg_name))
-
-    @unittest.skip("We no longer depend on system tor")
-    def test_tor_daemon_running(self):
-        """Make sure we've a running tor process.
-        The library can be used without having tor installed on the system,
-        using Stem as a replacement.
-        """
-
-        cmd = "ps -ax | grep -w tor | grep -v grep"
-        _, output = run_cmd(cmd)
-        self.assertIn("/usr/bin/tor", output,
-                      """Can't find the running tor process.
-                      The tests (test_tbdriver) that depend on tor may fail.
-                      You can run '(sudo) service tor start' to start tor.
-
-                      If you don't want to run the tests, you may use Stem
-                      instead of tor installed on the system.
-                      """)
-
-    @unittest.skip("We no longer depend on system tor")
+    @pytest.mark.skipif("CI" not in environ, reason="Only runs on CI")
     def test_default_tor_ports(self):
         """Make sure tor is listening on the port we expect."""
-        self.assertTrue(is_connectable(cm.DEFAULT_SOCKS_PORT),
-                        """No process is listening on SOCKS port %s!""" %
-                        cm.DEFAULT_SOCKS_PORT)
+        self.assertTrue(is_connectable(cm.DEFAULT_SOCKS_PORT))
 
     def test_selenium(self):
         self.assert_py_pkg_installed('selenium')

--- a/tbselenium/utils.py
+++ b/tbselenium/utils.py
@@ -1,24 +1,8 @@
-from subprocess import STDOUT, check_output, CalledProcessError
 import sqlite3
 from os import walk
 from os.path import join
 import fnmatch
 from hashlib import sha256
-try:
-    from subprocess import getstatusoutput  # added in Python 3
-except ImportError:
-    # Taken from https://hg.python.org/cpython/file/3.4/Lib/subprocess.py#l694
-    def getstatusoutput(cmd):
-        try:
-            data = check_output(cmd, shell=True, universal_newlines=True,
-                                stderr=STDOUT)
-            status = 0
-        except CalledProcessError as ex:
-            data = ex.output
-            status = ex.returncode
-        if data[-1:] == '\n':
-            data = data[:-1]
-        return status, data
 
 
 def get_hash_of_directory(dir_path):
@@ -49,10 +33,6 @@ def is_png(path):
     # Taken from http://stackoverflow.com/a/21555489
     data = read_file(path, 'rb')
     return (data[:8] == '\211PNG\r\n\032\n'and (data[12:16] == 'IHDR'))
-
-
-def run_cmd(cmd):
-    return getstatusoutput('%s ' % cmd)
 
 
 def add_canvas_permission(profile_path, canvas_allowed_hosts):
@@ -86,8 +66,9 @@ def add_canvas_permission(profile_path, canvas_allowed_hosts):
       appId INTEGER,
       isInBrowserElement INTEGER)""")
     for host in canvas_allowed_hosts:
-        qry = """INSERT INTO 'moz_hosts'
-        VALUES(NULL,'%s','canvas/extractData',1,0,0,0,0);""" % host
-        cursor.execute(qry)
+        if host:
+            qry = """INSERT INTO 'moz_hosts'
+            VALUES(NULL,'%s','canvas/extractData',1,0,0,0,0);""" % host
+            cursor.execute(qry)
     perm_db.commit()
     cursor.close()


### PR DESCRIPTION
Remove unused assert_installed routine.
Remove unused test_tor_daemon_running test.

Run test_default_tor_ports only on CI, where Tor is guaranteeed
to be running.

Remove lsof and shell dependency (per #24) of the loaded library test
(test_should_load_tbb_firefox_libs). Use process memory map.

Check hostname before adding to db for canvas exemption.