### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os: linux
 dist: trusty
 python:
   - "2.7"
+  - "3.5"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pyvirtualdisplay
+stem
+pytest

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -1,5 +1,4 @@
 import shutil
-from six import iteritems
 from os import environ, chdir
 from os.path import isdir, isfile, join, abspath
 from time import sleep
@@ -223,7 +222,7 @@ class TorBrowserDriver(FirefoxDriver):
         else:
             self.set_tb_prefs_for_using_system_tor(control_port)
         # pref_dict overwrites above preferences
-        for pref_name, pref_val in iteritems(pref_dict):
+        for pref_name, pref_val in pref_dict.items():
             set_pref(pref_name, pref_val)
         self.profile.update_preferences()
 

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -1,5 +1,5 @@
 import shutil
-from httplib import CannotSendRequest
+from six import iteritems
 from os import environ, chdir
 from os.path import isdir, isfile, join, abspath
 from time import sleep
@@ -10,10 +10,15 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.firefox.webdriver import WebDriver as FirefoxDriver
-
-import common as cm
-from tbselenium.utils import add_canvas_permission
 from selenium.common.exceptions import TimeoutException
+
+import tbselenium.common as cm
+from tbselenium.utils import add_canvas_permission
+
+try:
+    from httplib import CannotSendRequest
+except ImportError:
+    from http.client import CannotSendRequest
 
 
 class TorBrowserDriver(FirefoxDriver):
@@ -135,7 +140,7 @@ class TorBrowserDriver(FirefoxDriver):
                 if self.current_url != "about:newtab" and \
                         self.title != "Problem loading page":  # TODO i18n?
                     break
-            except TimeoutException, last_err:
+            except TimeoutException as last_err:
                 continue
         else:
             if last_err:
@@ -218,7 +223,7 @@ class TorBrowserDriver(FirefoxDriver):
         else:
             self.set_tb_prefs_for_using_system_tor(control_port)
         # pref_dict overwrites above preferences
-        for pref_name, pref_val in pref_dict.iteritems():
+        for pref_name, pref_val in iteritems(pref_dict):
             set_pref(pref_name, pref_val)
         self.profile.update_preferences()
 
@@ -261,7 +266,7 @@ class TorBrowserDriver(FirefoxDriver):
         try:
             super(TorBrowserDriver, self).quit()
         except CannotSendRequest as exc:
-            print("[tbselenium] " + str(exc))
+            print("[tbselenium] %s" % exc)
             # following code is from webdriver.firefox.webdriver.quit()
             try:
                 self.binary.kill()  # kill the browser
@@ -269,7 +274,7 @@ class TorBrowserDriver(FirefoxDriver):
                 if self.profile.tempfolder is not None:
                     shutil.rmtree(self.profile.tempfolder)
             except Exception as e:
-                print("[tbselenium] " + str(e))
+                print("[tbselenium] %s" % e)
 
     def __enter__(self):
         return self

--- a/tbselenium/test/test_env.py
+++ b/tbselenium/test/test_env.py
@@ -28,7 +28,7 @@ class EnvironmentTest(unittest.TestCase):
         min_v = 2
         min_minor_v = 45
         min_micro_v = 0
-        version, minor_v, micro_v = pkg_ver.split('.')
+        version, minor_v, micro_v = [int(v) for v in pkg_ver.split('.')]
         self.assertGreaterEqual(version, min_v, err_msg)
         if version == min_v:
             self.assertGreaterEqual(minor_v, min_minor_v, err_msg)

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -53,10 +53,10 @@ class TBDriverTest(unittest.TestCase):
     def test_tbdriver_profile_not_modified(self):
         """Visiting a site should not modify the original profile contents."""
         profile_path = join(TBB_PATH, cm.DEFAULT_TBB_PROFILE_PATH)
-        profile_hash_before = ut.get_hash_of_directory(profile_path)
+        last_mod_time_before = ut.get_last_modified_of_dir(profile_path)
         self.tb_driver.load_url_ensure(cm.CHECK_TPO_URL)
-        profile_hash_after = ut.get_hash_of_directory(profile_path)
-        self.assertEqual(profile_hash_before, profile_hash_after)
+        last_mod_time_after = ut.get_last_modified_of_dir(profile_path)
+        self.assertEqual(last_mod_time_before, last_mod_time_after)
 
     def test_httpseverywhere(self):
         """HTTPSEverywhere should redirect to HTTPS version."""
@@ -184,8 +184,6 @@ class ScreenshotTest(unittest.TestCase):
         # A real screen capture of the same page is ~57KB. If the capture
         # is not blank it should be at least greater than 20KB.
         self.assertGreater(getsize(self.temp_file), 20000)
-        self.assertTrue(ut.is_png(self.temp_file),
-                        "Doesn't look like a PNG file")
 
 
 class TBDriverOptionalArgs(unittest.TestCase):
@@ -329,20 +327,20 @@ class TBDriverOptionalArgs(unittest.TestCase):
         """
         tmp_dir = tempfile.mkdtemp()
         tbb_tor_data_path = join(TBB_PATH, cm.DEFAULT_TOR_DATA_PATH)
-        hash_before = ut.get_hash_of_directory(tbb_tor_data_path)
+        last_mod_time_before = ut.get_last_modified_of_dir(tbb_tor_data_path)
         with TorBrowserDriver(TBB_PATH, tor_data_dir=tmp_dir) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL)
-        hash_after = ut.get_hash_of_directory(tbb_tor_data_path)
-        self.assertEqual(hash_before, hash_after)
+        last_mod_time_after = ut.get_last_modified_of_dir(tbb_tor_data_path)
+        self.assertEqual(last_mod_time_before, last_mod_time_after)
 
     def test_non_temp_tor_data_dir(self):
         """Tor data dir in TBB should change if we don't use tor_data_dir."""
         tbb_tor_data_path = join(TBB_PATH, cm.DEFAULT_TOR_DATA_PATH)
-        hash_before = ut.get_hash_of_directory(tbb_tor_data_path)
+        last_mod_time_before = ut.get_last_modified_of_dir(tbb_tor_data_path)
         with TorBrowserDriver(TBB_PATH) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL)
-        hash_after = ut.get_hash_of_directory(tbb_tor_data_path)
-        self.assertNotEqual(hash_before, hash_after)
+        last_mod_time_after = ut.get_last_modified_of_dir(tbb_tor_data_path)
+        self.assertNotEqual(last_mod_time_before, last_mod_time_after)
 
 
 class TBDriverTestAssumptions(unittest.TestCase):

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -6,7 +6,9 @@ import unittest
 from os import remove, environ
 from os.path import getsize, exists, join, dirname, isfile
 
-from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from selenium.common.exceptions import (TimeoutException,
+                                        NoSuchElementException,
+                                        WebDriverException)
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -37,7 +39,7 @@ class TBDriverTest(unittest.TestCase):
             try:
                 self.tb_driver = TorBrowserDriver(TBB_PATH)
                 break
-            except TimeoutException as exc:
+            except (TimeoutException, WebDriverException) as exc:
                 continue
         else:
             raise exc

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -37,7 +37,7 @@ class TBDriverTest(unittest.TestCase):
             try:
                 self.tb_driver = TorBrowserDriver(TBB_PATH)
                 break
-            except TimeoutException, exc:
+            except TimeoutException as exc:
                 continue
         else:
             raise exc
@@ -216,8 +216,7 @@ class TBDriverOptionalArgs(unittest.TestCase):
             from stem.control import Controller
             from stem.process import launch_tor_with_config
         except ImportError as err:
-            print("Skipping Stem test. Install stem to run this test: %s" %
-                  err)
+            print("Can't import Stem. Skipping test: %s" % err)
             return
         custom_tor_binary = join(TBB_PATH, cm.DEFAULT_TOR_BINARY_PATH)
         environ["LD_LIBRARY_PATH"] = dirname(custom_tor_binary)

--- a/tbselenium/test/test_utils.py
+++ b/tbselenium/test/test_utils.py
@@ -1,31 +1,21 @@
 import tempfile
 import unittest
-from os import makedirs
 from os.path import join
 import tbselenium.utils as ut
+from time import sleep
 
 
 class UtilsTest(unittest.TestCase):
 
-    def test_hashes_of_empty_folders_should_be_equal(self):
-        """Even though folders have different paths."""
+    def test_writing_bytes_should_change_dir_mod_time(self):
         temp_dir = tempfile.mkdtemp()
-        dir1_path = join(temp_dir, "dir1")
-        makedirs(dir1_path)
-        dir2_path = join(temp_dir, "dir2")
-        makedirs(dir2_path)
-        dir1_hash = ut.get_hash_of_directory(dir1_path)
-        dir2_hash = ut.get_hash_of_directory(dir2_path)
-        self.assertEqual(dir1_hash, dir2_hash)
-
-    def test_writing_bytes_should_change_dir_hash(self):
-        temp_dir = tempfile.mkdtemp()
-        hash_before = ut.get_hash_of_directory(temp_dir)
+        last_mod_time_before = ut.get_last_modified_of_dir(temp_dir)
         temp_file = join(temp_dir, 'temp_file')
+        sleep(0.1)
         with open(temp_file, 'a') as f:
             f.write('\0')
-        hash_after = ut.get_hash_of_directory(temp_dir)
-        self.assertNotEqual(hash_before, hash_after)
+        last_mod_time_after = ut.get_last_modified_of_dir(temp_dir)
+        self.assertNotEqual(last_mod_time_before, last_mod_time_after)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tbselenium/utils.py
+++ b/tbselenium/utils.py
@@ -1,16 +1,12 @@
 import sqlite3
 from os import walk
-from os.path import join
+from os.path import join, getmtime
 import fnmatch
-from hashlib import sha256
 
 
-def get_hash_of_directory(dir_path):
-    """Return sha256 hash of the directory pointed by path."""
-    m = sha256()
-    for file_path in gen_find_files(dir_path):
-        m.update(read_file(file_path))
-    return m.digest()
+def get_last_modified_of_dir(dir_path):
+    """Recursively get the last modified time of a directory."""
+    return max(getmtime(_dir) for _dir, _, _ in walk(dir_path))
 
 
 def gen_find_files(dir_path, pattern="*"):
@@ -27,12 +23,6 @@ def read_file(file_path, mode='rU'):
     with open(file_path, mode) as f:
         content = f.read()
     return content
-
-
-def is_png(path):
-    # Taken from http://stackoverflow.com/a/21555489
-    data = read_file(path, 'rb')
-    return (data[:8] == '\211PNG\r\n\032\n'and (data[12:16] == 'IHDR'))
 
 
 def add_canvas_permission(profile_path, canvas_allowed_hosts):


### PR DESCRIPTION
Add Python3 support based on 2to3 recommendations.

Remove redundant get_hash_of_directory function.
Add a function to get the last modification time of a directory.

Add requirements-dev.txt, the Python packages needed for testing.

Fix int-string comparison error.

Remove `six` package, replace `iteritems` with `items`.

Remove barely useful is_png test.

Handle WebDriverException during TBDriverTest initialization.