### PR TITLE
Ci multiple tbb versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
   - "2.7"
   - "3.5"
 env:
-  - FOO=foo BAR=bar
-  - FOO=bar BAR=foo
+  - export TBB_PATH=$HOME/tbb554/tor-browser_en-US
+  - export TBB_PATH=$HOME/tbb60a4/tor-browser_en-US
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
@@ -15,8 +15,12 @@ install:
   - pip install -r requirements-travis.txt
   - sudo apt-get -qq install tor
   - easy_install .
+  - mkdir $HOME/tbb554
   - wget https://archive.torproject.org/tor-package-archive/torbrowser/5.5.4/tor-browser-linux64-5.5.4_en-US.tar.xz
-  - tar -xvf tor-browser-linux64-5.5.4_en-US.tar.xz
+  - tar -xvf tor-browser-linux64-5.5.4_en-US.tar.xz -C $HOME/tbb554
+  - mkdir $HOME/tbb60a4
+  - wget https://archive.torproject.org/tor-package-archive/torbrowser/6.0a4/tor-browser-linux64-6.0a4_en-US.tar.xz
+  - tar -xvf tor-browser-linux64-6.0a4_en-US.tar.xz -C $HOME/tbb60a4
 before_script:
   - cd tbselenium/test
   - export TBB_PATH=../../tor-browser_en-US

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.5"
 env:
   - export TBB_PATH=$HOME/tbb554/tor-browser_en-US
+  - export TBB_PATH=$HOME/tbb554/tor-browser_zh-CN
   - export TBB_PATH=$HOME/tbb60a4/tor-browser_en-US
   - export TBB_PATH=$HOME/tbb60a4/tor-browser_zh-CN
 before_install:
@@ -19,6 +20,8 @@ install:
   - mkdir $HOME/tbb554
   - wget https://archive.torproject.org/tor-package-archive/torbrowser/5.5.4/tor-browser-linux64-5.5.4_en-US.tar.xz
   - tar -xvf tor-browser-linux64-5.5.4_en-US.tar.xz -C $HOME/tbb554
+  - wget https://archive.torproject.org/tor-package-archive/torbrowser/5.5.4/tor-browser-linux64-5.5.4_zh-CN.tar.xz
+  - tar -xvf tor-browser-linux64-5.5.4_zh-CN.tar.xz -C $HOME/tbb554
   - mkdir $HOME/tbb60a4
   - wget https://archive.torproject.org/tor-package-archive/torbrowser/6.0a4/tor-browser-linux64-6.0a4_en-US.tar.xz
   - tar -xvf tor-browser-linux64-6.0a4_en-US.tar.xz -C $HOME/tbb60a4

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,4 @@ install:
   - tar -xvf tor-browser-linux64-6.0a4_en-US.tar.xz -C $HOME/tbb60a4
 before_script:
   - cd tbselenium/test
-  - export TBB_PATH=../../tor-browser_en-US
 script:  py.test -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: trusty
 python:
   - "2.7"
   - "3.5"
+env:
+  - FOO=foo BAR=bar
+  - FOO=bar BAR=foo
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 env:
   - export TBB_PATH=$HOME/tbb554/tor-browser_en-US
   - export TBB_PATH=$HOME/tbb60a4/tor-browser_en-US
+  - export TBB_PATH=$HOME/tbb60a4/tor-browser_zh-CN
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
@@ -21,6 +22,8 @@ install:
   - mkdir $HOME/tbb60a4
   - wget https://archive.torproject.org/tor-package-archive/torbrowser/6.0a4/tor-browser-linux64-6.0a4_en-US.tar.xz
   - tar -xvf tor-browser-linux64-6.0a4_en-US.tar.xz -C $HOME/tbb60a4
+  - wget https://archive.torproject.org/tor-package-archive/torbrowser/6.0a4/tor-browser-linux64-6.0a4_zh-CN.tar.xz
+  - tar -xvf tor-browser-linux64-6.0a4_zh-CN.tar.xz -C $HOME/tbb60a4
 before_script:
   - cd tbselenium/test
 script:  py.test -s

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -210,6 +210,7 @@ class TorBrowserDriver(FirefoxDriver):
         set_pref('extensions.torbutton.versioncheck_enabled', False)
         # following is only needed for TBB < 4.5a3 to add canvas permissions
         set_pref('permissions.memory_only', False)
+        set_pref('extensions.torbutton.prompted_language', True)
         # Configure Firefox to use Tor SOCKS proxy
         set_pref('network.proxy.socks_port', self.socks_port)
         set_pref('extensions.torbutton.socks_port', self.socks_port)

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -163,7 +163,10 @@ class TBDriverFailTest(unittest.TestCase):
         with TorBrowserDriver(TBB_PATH, socks_port=9999,
                               tor_cfg=cm.USE_RUNNING_TOR) as driver:
             driver.load_url(cm.CHECK_TPO_URL)
-            self.assertEqual(driver.title, "Problem loading page")
+            page_source = driver.page_source
+            for moz_err_text in ["connectionFailure", "errorTitleText",
+                                 "errorLongContent", "loadError", "Mozilla"]:
+                self.assertIn(moz_err_text, page_source)
 
 
 class ScreenshotTest(unittest.TestCase):

--- a/tbselenium/utils.py
+++ b/tbselenium/utils.py
@@ -1,3 +1,4 @@
+import re
 import sqlite3
 from os import walk
 from os.path import join, getmtime
@@ -16,6 +17,14 @@ def gen_find_files(dir_path, pattern="*"):
     for path, _, filelist in walk(dir_path):
         for name in fnmatch.filter(filelist, pattern):
             yield join(path, name)
+
+
+def get_tbb_version(src):
+    match = re.search(r'Tor Browser.([^<]*)', src,
+                      flags=re.MULTILINE | re.DOTALL)
+    if not match:
+        return ""
+    return match.group(0)
 
 
 def read_file(file_path, mode='rU'):

--- a/tbselenium/utils.py
+++ b/tbselenium/utils.py
@@ -20,11 +20,11 @@ def gen_find_files(dir_path, pattern="*"):
 
 
 def get_tbb_version(src):
-    match = re.search(r'Tor Browser.([^<]*)', src,
+    match = re.search(r'(Tor Browser.)([^<]*)', src,
                       flags=re.MULTILINE | re.DOTALL)
     if not match:
         return ""
-    return match.group(0)
+    return match.group(2)
 
 
 def read_file(file_path, mode='rU'):


### PR DESCRIPTION
Run CI tests with two versions of TBB.
Check TBB version before running bundled font test.
Fix version string regexp, add Chinese localized TBB to CI tests.
Set preference to avoid language spoofing alert box in Chinese TBB.
Change the way we check the network error page.
Add 5.5.4 Chinese TBB to CI tests.