### PR TITLE
Refactor tests, default to system tor for the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ install:
   - export TBB_PATH=$HOME/tor-browser_$locale
 before_script:
   - cd tbselenium/test
-script: travis_retry py.test -s --cov=tbselenium --cov-report term-missing --durations=10
+script: travis_retry py.test -s -v --cov=tbselenium --cov-report term-missing --durations=10

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -273,7 +273,7 @@ class TorBrowserDriver(FirefoxDriver):
         self.is_running = False
         try:
             super(TorBrowserDriver, self).quit()
-        except CannotSendRequest as exc:
+        except (CannotSendRequest, AttributeError) as exc:
             print("[tbselenium] %s" % exc)
             # following code is from webdriver.firefox.webdriver.quit()
             try:

--- a/tbselenium/test/fixtures.py
+++ b/tbselenium/test/fixtures.py
@@ -89,7 +89,7 @@ def launch_tor_with_config_fixture(*args, **kwargs):
             continue
         except OSError as last_err:
             print ("\nlaunch_tor try %s %s" % ((tries + 1), last_err))
-            if "timeout without success" in str(last_err.exception):
+            if "timeout without success" in str(last_err):
                 continue
             else:
                 raise

--- a/tbselenium/test/fixtures.py
+++ b/tbselenium/test/fixtures.py
@@ -1,8 +1,10 @@
 import signal
 from tbselenium.tbdriver import TorBrowserDriver
-from tbselenium.common import TB_INIT_TIMEOUT
+import tbselenium.common as cm
 from tbselenium.exceptions import TimeExceededError
 from selenium.common.exceptions import (TimeoutException, WebDriverException)
+from selenium.webdriver.common.utils import is_connectable
+
 try:
     from httplib import CannotSendRequest
 except ImportError:
@@ -13,27 +15,46 @@ except ImportError as err:
     pass
 
 MAX_FIXTURE_TRIES = 3
-LAUNCH_TOR_TIMEOUT = 30
+EXTERNAL_TIMEOUT_GRACE = 5  # only fire if the internal timeout fails
+LAUNCH_TOR_TIMEOUT = 30 + EXTERNAL_TIMEOUT_GRACE
 LOAD_PAGE_TIMEOUT = 60
+TB_INIT_EXT_TIMEOUT = cm.TB_INIT_TIMEOUT + EXTERNAL_TIMEOUT_GRACE
 
 
 class TorBrowserDriverFixture(TorBrowserDriver):
     """Extend TorBrowserDriver to have fixtures for tests."""
     def __init__(self, *args, **kwargs):
         last_err = RuntimeError("Unknown error")
+        self.change_default_tor_cfg(kwargs)
         for tries in range(MAX_FIXTURE_TRIES):
             try:
-                timeout(TB_INIT_TIMEOUT)
+                timeout(TB_INIT_EXT_TIMEOUT)
                 return super(TorBrowserDriverFixture, self).__init__(*args,
                                                                      **kwargs)
             except (TimeoutException, WebDriverException,
                     TimeExceededError) as last_err:
-                print ("\nTBDriver init try %s %s" % ((tries + 1), last_err))
+                print ("\nTBDriver init timed out. Attempt %s %s" %
+                       ((tries + 1), last_err))
+                super(TorBrowserDriverFixture, self).quit()  # clean up
                 continue
             finally:
                 cancel_timeout()
         else:
             raise last_err
+
+    def change_default_tor_cfg(self, kwargs):
+        """Use system Tor if the caller doesn't specifically wants
+        to launch a new TBB Tor.
+
+        This makes tests faster and more robust against network
+        issues since otherwise we'd have to launch a new Tor process
+        for each test.
+        """
+
+        if kwargs.get("tor_cfg") != cm.LAUNCH_NEW_TBB_TOR and\
+                is_connectable(cm.DEFAULT_SOCKS_PORT):
+            kwargs["tor_cfg"] = cm.USE_RUNNING_TOR
+            # print ("Will use system Tor for the test")
 
     def load_url_ensure(self, *args, **kwargs):
         """Make sure the requested URL is loaded. Retry if necessary."""
@@ -47,7 +68,8 @@ class TorBrowserDriverFixture(TorBrowserDriver):
                     break
             except (TimeoutException, TimeExceededError,
                     CannotSendRequest) as last_err:
-                print ("\nload_url try %s %s" % ((tries + 1), last_err))
+                print ("\nload_url timed out.  Attempt %s %s" %
+                       ((tries + 1), last_err))
                 continue
             finally:
                 cancel_timeout()
@@ -62,7 +84,8 @@ def launch_tor_with_config_fixture(*args, **kwargs):
             timeout(LAUNCH_TOR_TIMEOUT)
             return launch_tor_with_config(*args, **kwargs)
         except TimeExceededError as last_err:
-            print ("\nlaunch_tor try %s %s" % ((tries + 1), last_err))
+            print ("\nlaunch_tor timed out. Attempt %s %s" %
+                   ((tries + 1), last_err))
             continue
         except OSError as last_err:
             print ("\nlaunch_tor try %s %s" % ((tries + 1), last_err))

--- a/tbselenium/test/test_addons.py
+++ b/tbselenium/test/test_addons.py
@@ -1,0 +1,67 @@
+import unittest
+
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from tbselenium import common as cm
+from tbselenium.test import TBB_PATH
+from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+
+
+class HTTPSEverywhereTest(unittest.TestCase):
+
+    # Test URLs are taken from the TBB test suite
+    # https://gitweb.torproject.org/boklm/tor-browser-bundle-testsuite.git/tree/marionette/tor_browser_tests/test_https-everywhere.py#n18
+    HE_HTTP_URL = "http://www.freedomboxfoundation.org/thanks/"
+    HE_HTTPS_URL = "https://www.freedomboxfoundation.org/thanks/"
+    TEST_LONG_WAIT = 60
+
+    def test_https_everywhere_redirection(self):
+        with TBDriverFixture(TBB_PATH) as driver:
+            driver.load_url_ensure(self.HE_HTTP_URL)
+            WebDriverWait(driver, self.TEST_LONG_WAIT).\
+                until(EC.title_contains("thanks"))
+            self.assertEqual(driver.current_url, self.HE_HTTPS_URL)
+
+    def test_https_everywhere_disabled(self):
+        """Make sure the HTTP->HTTPS redirection in the above test
+        is due to HTTPSEverywhere - not because the site is forwarding
+        to HTTPS by default.
+
+        We have to find another test site if this test starts to fail.
+        """
+
+        disable_HE_pref = {"extensions.https_everywhere.globalEnabled": False}
+        with TBDriverFixture(TBB_PATH, pref_dict=disable_HE_pref) as driver:
+            driver.load_url_ensure(self.HE_HTTP_URL, 1)
+            self.assertEqual(driver.current_url, self.HE_HTTP_URL)
+
+
+class NoScriptTest(unittest.TestCase):
+
+    WEBGL_CHECK_JS = "var cvs = document.createElement('canvas');\
+                    return cvs.getContext('experimental-webgl');"
+
+    def test_noscript(self):
+        """NoScript should disable WebGL."""
+        with TBDriverFixture(TBB_PATH) as driver:
+            driver.load_url_ensure(cm.CHECK_TPO_URL,
+                                   wait_for_page_body=True)
+            webgl_support = driver.execute_script(self.WEBGL_CHECK_JS)
+            self.assertIsNone(webgl_support)
+
+    def test_noscript_webgl_enabled(self):
+        """Make sure that when we disable NoScript's WebGL blocking,
+        WebGL becomes available. This is to the test method we
+        use in test_noscript is sane.
+        """
+        disable_NS_webgl_pref = {"noscript.forbidWebGL": False}
+        with TBDriverFixture(TBB_PATH,
+                             pref_dict=disable_NS_webgl_pref) as driver:
+            driver.load_url_ensure(cm.CHECK_TPO_URL, wait_for_page_body=True)
+            webgl_support = driver.execute_script(self.WEBGL_CHECK_JS)
+            self.assertIn("getSupportedExtensions", webgl_support)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tbselenium/test/test_browser.py
+++ b/tbselenium/test/test_browser.py
@@ -1,0 +1,62 @@
+import pytest
+import sys
+import unittest
+import tempfile
+from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium import common as cm
+from tbselenium.test import TBB_PATH
+import tbselenium.utils as ut
+
+from os.path import exists, join
+from os import remove
+
+
+class TorBrowserTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.log_file = tempfile.mkstemp()
+        cls.driver = TBDriverFixture(TBB_PATH, tbb_logfile_path=cls.log_file)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.driver:
+            cls.driver.quit()
+        if exists(cls.log_file):
+            remove(cls.log_file)
+
+    def test_correct_firefox_binary(self):
+        self.assertTrue(self.driver.binary.which('firefox').
+                        startswith(TBB_PATH))
+
+    def test_tbb_logfile(self):
+        log_txt = ut.read_file(self.log_file)
+        self.assertIn("torbutton@torproject.org", log_txt)
+        self.assertIn("addons.manager", log_txt)
+
+    @pytest.mark.skipif(sys.platform != 'linux2', reason='Requires Linux')
+    def test_should_load_tbb_firefox_libs(self):
+        """Make sure we load the Firefox libraries from the TBB directories.
+        We only test libxul (main Firefox/Gecko library) and libstdc++.
+
+        The memory map of the TB process is used to find loaded libraries.
+        http://man7.org/linux/man-pages/man5/proc.5.html
+        """
+
+        driver = self.driver
+        pid = driver.binary.process.pid
+        xul_lib_path = join(driver.tbb_browser_dir, "libxul.so")
+        std_c_lib_path = join(driver.tbb_path, cm.DEFAULT_TOR_BINARY_DIR,
+                              "libstdc++.so.6")
+        proc_mem_map_file = "/proc/%d/maps" % (pid)
+        mem_map = ut.read_file(proc_mem_map_file)
+        self.assertIn(xul_lib_path, mem_map)
+        self.assertIn(std_c_lib_path, mem_map)
+
+    def test_tbdriver_fx_profile_not_be_modified(self):
+        """Visiting a site should not modify the original profile contents."""
+        profile_path = join(TBB_PATH, cm.DEFAULT_TBB_PROFILE_PATH)
+        mtime_before = ut.get_last_modified_of_dir(profile_path)
+        self.driver.load_url_ensure(cm.CHECK_TPO_URL)
+        mtime_after = ut.get_last_modified_of_dir(profile_path)
+        self.assertEqual(mtime_before, mtime_after)

--- a/tbselenium/test/test_bundled_fonts.py
+++ b/tbselenium/test/test_bundled_fonts.py
@@ -18,13 +18,13 @@ class TBDriverFontBundle(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         _, log_file = tempfile.mkstemp()
+        # https://www.freedesktop.org/software/fontconfig/fontconfig-user.html
         environ["FC_DEBUG"] = "%d" % (1024 + 8 + 1)
         cls.driver = TBDTestFixture(TBB_PATH, tbb_logfile_path=log_file)
         driver = cls.driver
         if not driver.supports_bundled_fonts:
             cls.tearDownClass()
             pytest.skip("Skip bundled font tests. V%s" % driver.tb_version)
-        # https://www.freedesktop.org/software/fontconfig/fontconfig-user.html
         driver.load_url_ensure("https://www.wikipedia.org/")
         cls.log_txt = ut.read_file(log_file)
         cls.bundled_fonts_dir = join(driver.tbb_path,
@@ -36,8 +36,9 @@ class TBDriverFontBundle(unittest.TestCase):
         if cls.driver:
             cls.driver.quit()
 
-    def test_should_load_font_config(self):
-        fonts_conf_path = join(TBB_PATH, cm.DEFAULT_FONTS_CONF_PATH)
+    def test_should_load_font_config_file(self):
+        fonts_conf_path = join(self.driver.tbb_path,
+                               cm.DEFAULT_FONTS_CONF_PATH)
         expected_log = "Loading config file %s" % fonts_conf_path
         self.assertIn(expected_log, self.log_txt)
 
@@ -45,14 +46,14 @@ class TBDriverFontBundle(unittest.TestCase):
         expected_log = "adding fonts from%s" % self.bundled_fonts_dir
         self.assertIn(expected_log, self.log_txt)
 
-    def test_ugly_output_log(self):
+    def test_should_not_fail_to_choose_fonts(self):
         ugly_warning = "failed to choose a font, expect ugly output"
         self.assertNotIn(ugly_warning, self.log_txt)
 
-    def test_tbb_should_include_bundled_fonts(self):
+    def test_tbb_should_include_bundled_font_files(self):
         self.assertTrue(len(self.bundled_font_files) > 0)
 
-    def test_only_load_and_use_bundled_fonts(self):
+    def test_should_only_load_and_use_bundled_fonts(self):
         used_font_files = set()
         # search in fontconfig logs
         for _, ttf, _ in re.findall(r"(file: \")(.*)(\".*)", self.log_txt):

--- a/tbselenium/test/test_bundled_fonts.py
+++ b/tbselenium/test/test_bundled_fonts.py
@@ -7,12 +7,12 @@ from os import environ
 from os.path import join
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDTestFixture
+from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
 import tbselenium.utils as ut
 
 
 @pytest.mark.skipif(sys.platform != 'linux2', reason='Requires Linux')
-class TBDriverFontBundle(unittest.TestCase):
+class TBBundledFonts(unittest.TestCase):
     """Use fontconfig's FC_DEBUG logs to test font bundling."""
 
     @classmethod
@@ -20,7 +20,7 @@ class TBDriverFontBundle(unittest.TestCase):
         _, log_file = tempfile.mkstemp()
         # https://www.freedesktop.org/software/fontconfig/fontconfig-user.html
         environ["FC_DEBUG"] = "%d" % (1024 + 8 + 1)
-        cls.driver = TBDTestFixture(TBB_PATH, tbb_logfile_path=log_file)
+        cls.driver = TBDriverFixture(TBB_PATH, tbb_logfile_path=log_file)
         driver = cls.driver
         if not driver.supports_bundled_fonts:
             cls.tearDownClass()

--- a/tbselenium/test/test_bundled_fonts.py
+++ b/tbselenium/test/test_bundled_fonts.py
@@ -1,0 +1,65 @@
+import sys
+import re
+import tempfile
+import pytest
+import unittest
+from os import environ
+from os.path import join
+from tbselenium import common as cm
+from tbselenium.test import TBB_PATH
+from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDTestFixture
+import tbselenium.utils as ut
+
+
+@pytest.mark.skipif(sys.platform != 'linux2', reason='Requires Linux')
+class TBDriverFontBundle(unittest.TestCase):
+    """Use fontconfig's FC_DEBUG logs to test font bundling."""
+
+    @classmethod
+    def setUpClass(cls):
+        _, log_file = tempfile.mkstemp()
+        environ["FC_DEBUG"] = "%d" % (1024 + 8 + 1)
+        cls.driver = TBDTestFixture(TBB_PATH, tbb_logfile_path=log_file)
+        driver = cls.driver
+        if not driver.supports_bundled_fonts:
+            cls.tearDownClass()
+            pytest.skip("Skip bundled font tests. V%s" % driver.tb_version)
+        # https://www.freedesktop.org/software/fontconfig/fontconfig-user.html
+        driver.load_url_ensure("https://www.wikipedia.org/")
+        cls.log_txt = ut.read_file(log_file)
+        cls.bundled_fonts_dir = join(driver.tbb_path,
+                                     cm.DEFAULT_BUNDLED_FONTS_PATH)
+        cls.bundled_font_files = set(ut.gen_find_files(cls.bundled_fonts_dir))
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.driver:
+            cls.driver.quit()
+
+    def test_should_load_font_config(self):
+        fonts_conf_path = join(TBB_PATH, cm.DEFAULT_FONTS_CONF_PATH)
+        expected_log = "Loading config file %s" % fonts_conf_path
+        self.assertIn(expected_log, self.log_txt)
+
+    def test_should_add_bundled_fonts(self):
+        expected_log = "adding fonts from%s" % self.bundled_fonts_dir
+        self.assertIn(expected_log, self.log_txt)
+
+    def test_ugly_output_log(self):
+        ugly_warning = "failed to choose a font, expect ugly output"
+        self.assertNotIn(ugly_warning, self.log_txt)
+
+    def test_tbb_should_include_bundled_fonts(self):
+        self.assertTrue(len(self.bundled_font_files) > 0)
+
+    def test_only_load_and_use_bundled_fonts(self):
+        used_font_files = set()
+        # search in fontconfig logs
+        for _, ttf, _ in re.findall(r"(file: \")(.*)(\".*)", self.log_txt):
+            self.assertIn(self.bundled_fonts_dir, ttf)
+            used_font_files.add(ttf)
+        self.assertEqual(used_font_files, self.bundled_font_files)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tbselenium/test/test_env.py
+++ b/tbselenium/test/test_env.py
@@ -21,6 +21,7 @@ class EnvironmentTest(unittest.TestCase):
         self.assert_py_pkg_installed('selenium')
 
     def test_py_selenium_version(self):
+        # TODO use LooseVersion
         import selenium
         pkg_ver = selenium.__version__
         err_msg = "Python Selenium package should be greater than 2.45.0"

--- a/tbselenium/test/test_examples.py
+++ b/tbselenium/test/test_examples.py
@@ -15,11 +15,7 @@ class TorBrowserDriverExamples(unittest.TestCase):
 
     @unittest.skip("Only for didactic purposes.")
     def test_visit_a_page(self):
-        """The most basic use of the TorBrowserDriver.
-
-        It assumes Tor is already running and SOCKS listening to the
-        default port.
-        """
+        """The most basic use of the TorBrowserDriver."""
         with TorBrowserDriver(TBB_PATH) as driver:
             driver.get(cm.TEST_URL)
             sleep(1)  # stay one second on the page
@@ -27,10 +23,7 @@ class TorBrowserDriverExamples(unittest.TestCase):
     @unittest.skip("Only for didactic purposes.")
     def test_take_screenshot(self):
         """Take screenshot of the page."""
-        # We need to add an exception for canvas access in the Tor Browser
-        # permission database. We need to do this for each site that we
-        # plan to visit.
-        canvas_allowed = [cm.CHECK_TPO_HOST]
+        canvas_allowed = [cm.CHECK_TPO_HOST]  # not needed for recent TBs
         with TorBrowserDriver(TBB_PATH,
                               canvas_allowed_hosts=canvas_allowed) as driver:
             driver.get(cm.TEST_URL)
@@ -44,17 +37,14 @@ class TorBrowserDriverExamples(unittest.TestCase):
         directory structure is different from the one that is currently
         used by Tor developers.
         """
-        # example for TBB 3.5, which we assume has been extracted in the home directory
+        # Assume we've extracted TBB 3.5 to our home directory
         tbb_3_5 = join(expanduser('~'), 'tor-browser_en-US')
         tb_binary = join(tbb_3_5, "Browser", "firefox")
         tb_profile = join(tbb_3_5, "Data", "Browser", "profile.default")
         with TorBrowserDriver(tbb_binary_path=tb_binary,
                               tbb_profile_path=tb_profile,
                               tbb_logfile_path="ff.log") as driver:
-            # as shown in the line above, you can also indicate the
-            # log file for the Tor Browser (firefox log).
             driver.get(cm.TEST_URL)
-            sleep(1)
 
     @unittest.skip("Only for didactic purposes.")
     def test_run_driver_with_stem_customized(self):
@@ -82,14 +72,15 @@ class TorBrowserDriverExamples(unittest.TestCase):
         # including the path and the level for logging in tor.
         # you can also use the DataDirectory property in torrc
         # to set a custom data directory for tor.
-        # For other options see: https://www.torproject.org/docs/tor-manual.html.en
+        # See other options: https://www.torproject.org/docs/tor-manual.html.en
         tor_process = launch_tor_with_config(config=torrc,
                                              tor_cmd=custom_tor_binary)
 
         with Controller.from_port(port=custom_control_port) as controller:
             controller.authenticate()
             # Visit the page with the TorBrowserDriver
-            with TorBrowserDriver(TBB_PATH, socks_port=custom_socks_port) as driver:
+            with TorBrowserDriver(TBB_PATH,
+                                  socks_port=custom_socks_port) as driver:
                 driver.get(cm.TEST_URL)
                 sleep(1)
 

--- a/tbselenium/test/test_exceptions.py
+++ b/tbselenium/test/test_exceptions.py
@@ -1,0 +1,68 @@
+import unittest
+import tempfile
+from tbselenium.exceptions import TBDriverPathError, TBDriverPortError
+from tbselenium.test import TBB_PATH
+from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium import common as cm
+
+MISSING_DIR = "_no_such_directory_"
+MISSING_FILE = "_no_such_file_"
+
+
+class TBDriverExceptions(unittest.TestCase):
+
+    def test_should_raise_for_missing_paths(self):
+        with self.assertRaises(TBDriverPathError) as exc:
+            TBDriverFixture()
+        exc_msg = exc.exception
+        self.assertEqual(str(exc_msg),
+                         "Either TBB path or Firefox profile and binary path "
+                         "should be provided ")
+
+    def test_should_raise_for_missing_tbb_path(self):
+        with self.assertRaises(TBDriverPathError) as exc:
+            TBDriverFixture(tbb_path=MISSING_DIR)
+        exc_msg = exc.exception
+        self.assertEqual(str(exc_msg),
+                         "TBB path is not a directory %s" % MISSING_DIR)
+
+    def test_should_raise_for_missing_fx_binary(self):
+        temp_dir = tempfile.mkdtemp()
+        with self.assertRaises(TBDriverPathError) as exc:
+            TBDriverFixture(tbb_fx_binary_path=MISSING_FILE,
+                            tbb_profile_path=temp_dir)
+        exc_msg = exc.exception
+        self.assertEqual(str(exc_msg),
+                         "Invalid Firefox binary %s" % MISSING_FILE)
+
+    def test_should_raise_for_missing_fx_profile(self):
+        _, temp_file = tempfile.mkstemp()
+        with self.assertRaises(TBDriverPathError) as exc:
+            TBDriverFixture(tbb_fx_binary_path=temp_file,
+                            tbb_profile_path=MISSING_DIR)
+        exc_msg = exc.exception
+        self.assertEqual(str(exc_msg),
+                         "Invalid Firefox profile dir %s" % MISSING_DIR)
+
+    def test_should_raise_for_invalid_pref_dict(self):
+        with self.assertRaises(AttributeError):
+            TBDriverFixture(TBB_PATH, pref_dict="foo")
+        with self.assertRaises(AttributeError):
+            TBDriverFixture(TBB_PATH, pref_dict=[1, 2])
+        with self.assertRaises(AttributeError):
+            TBDriverFixture(TBB_PATH, pref_dict=(1, 2))
+
+    def test_should_fail_launching_tor_on_custom_socks_port(self):
+        with self.assertRaises(TBDriverPortError):
+            TBDriverFixture(TBB_PATH, socks_port=10001,
+                            tor_cfg=cm.LAUNCH_NEW_TBB_TOR)
+
+    def test_should_not_load_with_wrong_sys_socks_port(self):
+        with TBDriverFixture(TBB_PATH, socks_port=9999,
+                             tor_cfg=cm.USE_RUNNING_TOR) as driver:
+            driver.load_url(cm.CHECK_TPO_URL)
+            self.assertTrue(driver.is_connection_error_page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tbselenium/test/test_screenshot.py
+++ b/tbselenium/test/test_screenshot.py
@@ -1,0 +1,47 @@
+import unittest
+import tempfile
+from os import remove
+from os.path import getsize, exists
+
+from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium import common as cm
+from tbselenium.test import TBB_PATH
+
+# A blank image for https://check.torproject.org/ amounts to ~4.8KB.
+# A real screen capture of the same page is ~57KB. If the capture
+# is not blank it should be at least greater than 20KB.
+SCREENSHOT_MIN_SIZE = 2000
+
+
+class ScreenshotTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.temp_file = tempfile.mkstemp()
+        # Passing canvas_allowed_hosts is not needed for TBB >= 4.5a3
+        canvas_allowed = [cm.CHECK_TPO_HOST]
+        cls.driver = TBDriverFixture(TBB_PATH,
+                                     canvas_allowed_hosts=canvas_allowed)
+        cls.driver.load_url_ensure(cm.CHECK_TPO_URL, 3)
+
+    @classmethod
+    def tearDownClass(cls):
+        if exists(cls.temp_file):
+            remove(cls.temp_file)
+        cls.driver.quit()
+
+    def test_screenshot_as_file(self):
+        self.driver.get_screenshot_as_file(self.temp_file)
+        self.assertGreater(getsize(self.temp_file), SCREENSHOT_MIN_SIZE)
+
+    def test_screenshot_as_base64(self):
+        base64_img = self.driver.get_screenshot_as_base64()
+        self.assertGreater(len(base64_img), SCREENSHOT_MIN_SIZE)
+
+    def test_screenshot_as_png(self):
+        png_data = self.driver.get_screenshot_as_png()
+        self.assertGreater(len(png_data), SCREENSHOT_MIN_SIZE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tbselenium/test/test_security_slider.py
+++ b/tbselenium/test/test_security_slider.py
@@ -1,0 +1,44 @@
+import unittest
+import pytest
+
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.webdriver.common.by import By
+
+from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium import common as cm
+from tbselenium.test import TBB_PATH
+
+SEC_SLIDER_PREF = "extensions.torbutton.security_slider"
+
+
+class TBSecuritySlider(unittest.TestCase):
+
+    def test_security_slider_settings_hi(self):
+        """Slider setting `High` should disable JavaScript."""
+        with TBDriverFixture(TBB_PATH,
+                             pref_dict={SEC_SLIDER_PREF: 1}) as driver:
+            if not driver.supports_sec_slider:
+                pytest.skip("Security slider is not supported")
+            driver.load_url_ensure(cm.CHECK_TPO_URL)
+            try:
+                driver.find_element_by("JavaScript is enabled.",
+                                       find_by=By.LINK_TEXT, timeout=5)
+                self.fail("Security slider should disable JavaScript")
+            except (NoSuchElementException, TimeoutException):
+                pass
+
+    def test_security_slider_settings_low_mid(self):
+        # TODO: test other features to distinguish between levels
+        # 2: medium-high, 3: medium-low, 4: low (default)
+        for sec_slider_setting in [2, 3, 4]:
+            slider_dict = {SEC_SLIDER_PREF: sec_slider_setting}
+            with TBDriverFixture(TBB_PATH, pref_dict=slider_dict) as driver:
+                if not driver.supports_sec_slider:
+                    pytest.skip("Security slider is not supported")
+                driver.load_url_ensure(cm.CHECK_TPO_URL)
+                driver.find_element_by("JavaScript is enabled.",
+                                       find_by=By.LINK_TEXT, timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tbselenium/test/test_stem.py
+++ b/tbselenium/test/test_stem.py
@@ -1,0 +1,43 @@
+import unittest
+import pytest
+import tempfile
+from os import environ
+from os.path import join, dirname
+
+from tbselenium.test.fixtures import launch_tor_with_config_fixture
+from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium import common as cm
+from tbselenium.test import TBB_PATH
+
+
+class TBStemTest(unittest.TestCase):
+
+    def test_running_with_stem(self):
+        """We should be able to run with a tor process started with Stem."""
+        try:
+            from stem.control import Controller
+        except ImportError as err:
+            pytest.skip("Can't import Stem. Skipping test: %s" % err)
+        custom_tor_binary = join(TBB_PATH, cm.DEFAULT_TOR_BINARY_PATH)
+        environ["LD_LIBRARY_PATH"] = dirname(custom_tor_binary)
+        # any port would do, pick 9250, 9251 to avoid conflict
+        socks_port = 9250
+        control_port = 9251
+        temp_data_dir = tempfile.mkdtemp()
+        torrc = {'ControlPort': str(control_port),
+                 'SOCKSPort': str(socks_port),
+                 'DataDirectory': temp_data_dir}
+        tor_process = launch_tor_with_config_fixture(config=torrc,
+                                                     tor_cmd=custom_tor_binary)
+        with Controller.from_port(port=control_port) as controller:
+            controller.authenticate()
+            with TBDriverFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR,
+                                 socks_port=socks_port) as driver:
+                driver.load_url_ensure(cm.CHECK_TPO_URL)
+                driver.find_element_by("h1.on")
+
+        if tor_process:
+            tor_process.kill()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -14,7 +14,7 @@ from selenium.webdriver.common.utils import is_connectable
 from tbselenium.exceptions import TBDriverPathError, TBDriverPortError
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDTestFixture
+from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
 from tbselenium.test.fixtures import launch_tor_with_config_fixture
 import tbselenium.utils as ut
 
@@ -36,7 +36,7 @@ SEC_SLIDER_PREF = "extensions.torbutton.security_slider"
 
 class TBDriverTest(unittest.TestCase):
     def setUp(self):
-        self.tb_driver = TBDTestFixture(TBB_PATH)
+        self.tb_driver = TBDriverFixture(TBB_PATH)
 
     def tearDown(self):
         self.tb_driver.quit()
@@ -100,7 +100,7 @@ class TBDriverFailTest(unittest.TestCase):
 
     def test_should_raise_for_missing_paths(self):
         with self.assertRaises(TBDriverPathError) as exc:
-            TBDTestFixture()
+            TBDriverFixture()
         exc_msg = exc.exception
         self.assertEqual(str(exc_msg),
                          "Either TBB path or Firefox profile and binary path "
@@ -108,7 +108,7 @@ class TBDriverFailTest(unittest.TestCase):
 
     def test_should_raise_for_missing_tbb_path(self):
         with self.assertRaises(TBDriverPathError) as exc:
-            TBDTestFixture(tbb_path=MISSING_DIR)
+            TBDriverFixture(tbb_path=MISSING_DIR)
         exc_msg = exc.exception
         self.assertEqual(str(exc_msg),
                          "TBB path is not a directory %s" % MISSING_DIR)
@@ -116,8 +116,8 @@ class TBDriverFailTest(unittest.TestCase):
     def test_should_raise_for_missing_fx_binary(self):
         temp_dir = tempfile.mkdtemp()
         with self.assertRaises(TBDriverPathError) as exc:
-            TBDTestFixture(tbb_fx_binary_path=MISSING_FILE,
-                           tbb_profile_path=temp_dir)
+            TBDriverFixture(tbb_fx_binary_path=MISSING_FILE,
+                            tbb_profile_path=temp_dir)
         exc_msg = exc.exception
         self.assertEqual(str(exc_msg),
                          "Invalid Firefox binary %s" % MISSING_FILE)
@@ -125,28 +125,28 @@ class TBDriverFailTest(unittest.TestCase):
     def test_should_raise_for_missing_fx_profile(self):
         _, temp_file = tempfile.mkstemp()
         with self.assertRaises(TBDriverPathError) as exc:
-            TBDTestFixture(tbb_fx_binary_path=temp_file,
-                           tbb_profile_path=MISSING_DIR)
+            TBDriverFixture(tbb_fx_binary_path=temp_file,
+                            tbb_profile_path=MISSING_DIR)
         exc_msg = exc.exception
         self.assertEqual(str(exc_msg),
                          "Invalid Firefox profile dir %s" % MISSING_DIR)
 
     def test_should_raise_for_invalid_pref_dict(self):
         with self.assertRaises(AttributeError):
-            TBDTestFixture(TBB_PATH, pref_dict="foo")
+            TBDriverFixture(TBB_PATH, pref_dict="foo")
         with self.assertRaises(AttributeError):
-            TBDTestFixture(TBB_PATH, pref_dict=[1, 2])
+            TBDriverFixture(TBB_PATH, pref_dict=[1, 2])
         with self.assertRaises(AttributeError):
-            TBDTestFixture(TBB_PATH, pref_dict=(1, 2))
+            TBDriverFixture(TBB_PATH, pref_dict=(1, 2))
 
     def test_should_fail_launching_tor_on_custom_socks_port(self):
         with self.assertRaises(TBDriverPortError):
-            TBDTestFixture(TBB_PATH, socks_port=10001,
-                           tor_cfg=cm.LAUNCH_NEW_TBB_TOR)
+            TBDriverFixture(TBB_PATH, socks_port=10001,
+                            tor_cfg=cm.LAUNCH_NEW_TBB_TOR)
 
     def test_should_not_load_with_wrong_sys_socks_port(self):
-        with TBDTestFixture(TBB_PATH, socks_port=9999,
-                            tor_cfg=cm.USE_RUNNING_TOR) as driver:
+        with TBDriverFixture(TBB_PATH, socks_port=9999,
+                             tor_cfg=cm.USE_RUNNING_TOR) as driver:
             driver.load_url(cm.CHECK_TPO_URL)
             self.assertTrue(driver.is_connection_error_page)
 
@@ -164,8 +164,8 @@ class ScreenshotTest(unittest.TestCase):
         Passing canvas_allowed_hosts is not needed for TBB >= 4.5a3
         """
         canvas_allowed = [cm.CHECK_TPO_HOST]
-        with TBDTestFixture(TBB_PATH,
-                            canvas_allowed_hosts=canvas_allowed) as driver:
+        with TBDriverFixture(TBB_PATH,
+                             canvas_allowed_hosts=canvas_allowed) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL, 3)
             driver.get_screenshot_as_file(self.temp_file)
         # A blank image for https://check.torproject.org/ amounts to ~4.8KB.
@@ -179,8 +179,8 @@ class TBDriverOptionalArgs(unittest.TestCase):
     def test_add_ports_to_fx_banned_ports(self):
         test_socks_port = 9999
         # No Tor process is listening on 9999, we just test the pref
-        with TBDTestFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR,
-                            socks_port=test_socks_port) as driver:
+        with TBDriverFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR,
+                             socks_port=test_socks_port) as driver:
             for pref in cm.PORT_BAN_PREFS:
                 banned_ports = driver.profile.default_preferences[pref]
                 self.assertIn(str(test_socks_port), banned_ports)
@@ -191,7 +191,7 @@ class TBDriverOptionalArgs(unittest.TestCase):
         """
         if not is_connectable(cm.DEFAULT_SOCKS_PORT):
             pytest.skip("Skipping. Start system Tor to run the test.")
-        with TBDTestFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR) as driver:
+        with TBDriverFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL)
             driver.find_element_by("h1.on")
 
@@ -214,8 +214,8 @@ class TBDriverOptionalArgs(unittest.TestCase):
                                                      tor_cmd=custom_tor_binary)
         with Controller.from_port(port=control_port) as controller:
             controller.authenticate()
-            with TBDTestFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR,
-                                socks_port=socks_port) as driver:
+            with TBDriverFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR,
+                                 socks_port=socks_port) as driver:
                 driver.load_url_ensure(cm.CHECK_TPO_URL)
                 driver.find_element_by("h1.on")
 
@@ -229,7 +229,7 @@ class TBDriverOptionalArgs(unittest.TestCase):
         log_len = len(ut.read_file(log_file))
         self.assertEqual(log_len, 0)
 
-        with TBDTestFixture(TBB_PATH, tbb_logfile_path=log_file) as driver:
+        with TBDriverFixture(TBB_PATH, tbb_logfile_path=log_file) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL)
 
         log_txt = ut.read_file(log_file)
@@ -246,7 +246,7 @@ class TBDriverOptionalArgs(unittest.TestCase):
         tmp_dir = tempfile.mkdtemp()
         tbb_tor_data_path = join(TBB_PATH, cm.DEFAULT_TOR_DATA_PATH)
         last_mod_time_before = ut.get_last_modified_of_dir(tbb_tor_data_path)
-        with TBDTestFixture(TBB_PATH, tor_data_dir=tmp_dir) as driver:
+        with TBDriverFixture(TBB_PATH, tor_data_dir=tmp_dir) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL)
         last_mod_time_after = ut.get_last_modified_of_dir(tbb_tor_data_path)
         self.assertEqual(last_mod_time_before, last_mod_time_after)
@@ -255,7 +255,7 @@ class TBDriverOptionalArgs(unittest.TestCase):
         """Tor data dir in TBB should change if we don't use tor_data_dir."""
         tbb_tor_data_path = join(TBB_PATH, cm.DEFAULT_TOR_DATA_PATH)
         last_mod_time_before = ut.get_last_modified_of_dir(tbb_tor_data_path)
-        with TBDTestFixture(TBB_PATH) as driver:
+        with TBDriverFixture(TBB_PATH) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL)
         last_mod_time_after = ut.get_last_modified_of_dir(tbb_tor_data_path)
         self.assertNotEqual(last_mod_time_before, last_mod_time_after)
@@ -265,8 +265,8 @@ class TBSecuritySlider(unittest.TestCase):
 
     def test_security_slider_settings_hi(self):
         """Setting `High` should disable JavaScript."""
-        with TBDTestFixture(TBB_PATH,
-                            pref_dict={SEC_SLIDER_PREF: 1}) as driver:
+        with TBDriverFixture(TBB_PATH,
+                             pref_dict={SEC_SLIDER_PREF: 1}) as driver:
             if not driver.supports_sec_slider:
                 pytest.skip("Security slider is not supported")
             driver.load_url_ensure(cm.CHECK_TPO_URL)
@@ -282,7 +282,7 @@ class TBSecuritySlider(unittest.TestCase):
         for sec_slider_setting in [2, 3, 4]:
             slider_dict = {SEC_SLIDER_PREF: sec_slider_setting}
             # 2: medium-high, 3: medium-low, 4: low (default)
-            with TBDTestFixture(TBB_PATH, pref_dict=slider_dict) as driver:
+            with TBDriverFixture(TBB_PATH, pref_dict=slider_dict) as driver:
                 if not driver.supports_sec_slider:
                     pytest.skip("Security slider is not supported")
                 driver.load_url_ensure(cm.CHECK_TPO_URL)
@@ -298,7 +298,7 @@ class TBDriverTestAssumptions(unittest.TestCase):
         not because the site is forwarding to HTTPS by default.
         """
         disable_HE_pref = {"extensions.https_everywhere.globalEnabled": False}
-        with TBDTestFixture(TBB_PATH, pref_dict=disable_HE_pref) as driver:
+        with TBDriverFixture(TBB_PATH, pref_dict=disable_HE_pref) as driver:
             driver.load_url_ensure(TEST_HTTP_URL, 1)
             err_msg = "Test should be updated to use a site that doesn't \
                 auto-forward HTTP to HTTPS. %s " % driver.current_url
@@ -312,8 +312,8 @@ class TBDriverTestAssumptions(unittest.TestCase):
         use in test_noscript is sane.
         """
         disable_NS_webgl_pref = {"noscript.forbidWebGL": False}
-        with TBDTestFixture(TBB_PATH,
-                            pref_dict=disable_NS_webgl_pref) as driver:
+        with TBDriverFixture(TBB_PATH,
+                             pref_dict=disable_NS_webgl_pref) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL, wait_for_page_body=True)
             webgl_support = driver.execute_script(WEBGL_CHECK_JS)
             self.assertIsNotNone(webgl_support)

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -1,33 +1,14 @@
-import sys
 import tempfile
 import pytest
 import unittest
-from os import remove, environ
-from os.path import getsize, exists, join, dirname, isfile
+from os.path import join
 
-from selenium.common.exceptions import NoSuchElementException, TimeoutException
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.utils import is_connectable
 
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
 from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
-from tbselenium.test.fixtures import launch_tor_with_config_fixture
 import tbselenium.utils as ut
-
-TEST_LONG_WAIT = 60
-
-WEBGL_CHECK_JS = "var cvs = document.createElement('canvas');\
-                    return cvs.getContext('experimental-webgl');"
-
-# Test URLs are taken from the TBB test suit
-# https://gitweb.torproject.org/boklm/tor-browser-bundle-testsuite.git/tree/marionette/tor_browser_tests/test_https-everywhere.py#n18
-TEST_HTTP_URL = "http://www.freedomboxfoundation.org/thanks/"
-TEST_HTTPS_URL = "https://www.freedomboxfoundation.org/thanks/"
-
-SEC_SLIDER_PREF = "extensions.torbutton.security_slider"
 
 
 class TBDriverTest(unittest.TestCase):
@@ -37,82 +18,15 @@ class TBDriverTest(unittest.TestCase):
     def tearDown(self):
         self.tb_driver.quit()
 
-    def test_tbdriver_simple_visit(self):
-        """check.torproject.org should detect Tor IP."""
+    def test_should_load_check_tpo(self):
+        congrats = "Congratulations. This browser is configured to use Tor."
         self.tb_driver.load_url_ensure(cm.CHECK_TPO_URL)
-        self.tb_driver.find_element_by("h1.on")
+        status = self.tb_driver.find_element_by("h1.on")
+        self.assertEqual(status.text, congrats)
 
-    def test_tbdriver_profile_not_modified(self):
-        """Visiting a site should not modify the original profile contents."""
-        profile_path = join(TBB_PATH, cm.DEFAULT_TBB_PROFILE_PATH)
-        last_mod_time_before = ut.get_last_modified_of_dir(profile_path)
-        self.tb_driver.load_url_ensure(cm.CHECK_TPO_URL)
-        last_mod_time_after = ut.get_last_modified_of_dir(profile_path)
-        self.assertEqual(last_mod_time_before, last_mod_time_after)
-
-    def test_httpseverywhere(self):
-        """HTTPSEverywhere should redirect to HTTPS version."""
-        self.tb_driver.load_url_ensure(TEST_HTTP_URL)
-        WebDriverWait(self.tb_driver, TEST_LONG_WAIT).\
-            until(EC.title_contains("thanks"))
-        self.assertEqual(self.tb_driver.current_url, TEST_HTTPS_URL)
-
-    def test_noscript(self):
-        """NoScript should disable WebGL."""
-        self.tb_driver.load_url_ensure(cm.CHECK_TPO_URL,
-                                       wait_for_page_body=True)
-        webgl_support = self.tb_driver.execute_script(WEBGL_CHECK_JS)
-        self.assertIsNone(webgl_support)
-
-    def test_correct_firefox_binary(self):
-        self.assertTrue(self.tb_driver.binary.which('firefox').
-                        startswith(TBB_PATH))
-
-    def test_should_load_tbb_firefox_libs(self):
-        """Make sure we load the Firefox libraries from the TBB directories.
-        We only test libxul (main Firefox/Gecko library) and libstdc++.
-        """
-        driver = self.tb_driver
-        if sys.platform == 'win32':
-            pytest.skip("This test doesn't support Windows")
-        pid = self.tb_driver.binary.process.pid
-        xul_lib_path = join(driver.tbb_browser_dir, "libxul.so")
-        std_c_lib_path = join(driver.tbb_path, cm.DEFAULT_TOR_BINARY_DIR,
-                              "libstdc++.so.6")
-        for lib_path in [xul_lib_path, std_c_lib_path]:
-            self.failUnless(isfile(lib_path))
-            # We read the memory map of the process
-            # http://man7.org/linux/man-pages/man5/proc.5.html
-            proc_mem_map_file = "/proc/%d/maps" % (pid)
-            self.assertTrue(isfile(proc_mem_map_file))
-            for map_line in open(proc_mem_map_file).readlines():
-                if lib_path in map_line:
-                    break  # Found the loaded library in the memory map
-            else:
-                self.fail("Can't find the loaded lib: %s" % (xul_lib_path))
-
-
-class ScreenshotTest(unittest.TestCase):
-    def setUp(self):
-        _, self.temp_file = tempfile.mkstemp()
-
-    def tearDown(self):
-        if exists(self.temp_file):
-            remove(self.temp_file)
-
-    def test_screen_capture(self):
-        """Make sure we can capture the screen.
-        Passing canvas_allowed_hosts is not needed for TBB >= 4.5a3
-        """
-        canvas_allowed = [cm.CHECK_TPO_HOST]
-        with TBDriverFixture(TBB_PATH,
-                             canvas_allowed_hosts=canvas_allowed) as driver:
-            driver.load_url_ensure(cm.CHECK_TPO_URL, 3)
-            driver.get_screenshot_as_file(self.temp_file)
-        # A blank image for https://check.torproject.org/ amounts to ~4.8KB.
-        # A real screen capture of the same page is ~57KB. If the capture
-        # is not blank it should be at least greater than 20KB.
-        self.assertGreater(getsize(self.temp_file), 20000)
+    def test_should_load_hidden_service(self):
+        self.tb_driver.load_url_ensure("http://3g2upl4pq6kufc4m.onion")
+        self.assertIn("DuckDuckGo", self.tb_driver.title)
 
 
 class TBDriverOptionalArgs(unittest.TestCase):
@@ -127,136 +41,36 @@ class TBDriverOptionalArgs(unittest.TestCase):
                 self.assertIn(str(test_socks_port), banned_ports)
 
     def test_running_with_system_tor(self):
-        """Make sure we can run using the tor running on the system.
-        This test requires a system tor process with SOCKS port 9050.
-        """
         if not is_connectable(cm.DEFAULT_SOCKS_PORT):
             pytest.skip("Skipping. Start system Tor to run the test.")
         with TBDriverFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL)
             driver.find_element_by("h1.on")
 
-    def test_running_with_stem(self):
-        """We should be able to run with a tor process started with Stem."""
-        try:
-            from stem.control import Controller
-        except ImportError as err:
-            pytest.skip("Can't import Stem. Skipping test: %s" % err)
-        custom_tor_binary = join(TBB_PATH, cm.DEFAULT_TOR_BINARY_PATH)
-        environ["LD_LIBRARY_PATH"] = dirname(custom_tor_binary)
-        # any port would do, pick 9250, 9251 to avoid conflict
-        socks_port = 9250
-        control_port = 9251
-        temp_data_dir = tempfile.mkdtemp()
-        torrc = {'ControlPort': str(control_port),
-                 'SOCKSPort': str(socks_port),
-                 'DataDirectory': temp_data_dir}
-        tor_process = launch_tor_with_config_fixture(config=torrc,
-                                                     tor_cmd=custom_tor_binary)
-        with Controller.from_port(port=control_port) as controller:
-            controller.authenticate()
-            with TBDriverFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR,
-                                 socks_port=socks_port) as driver:
-                driver.load_url_ensure(cm.CHECK_TPO_URL)
-                driver.find_element_by("h1.on")
-
-        # Kill tor process
-        if tor_process:
-            tor_process.kill()
-
-    def test_tbb_logfile(self):
-        """Make sure log file is populated."""
-        _, log_file = tempfile.mkstemp()
-        log_len = len(ut.read_file(log_file))
-        self.assertEqual(log_len, 0)
-
-        with TBDriverFixture(TBB_PATH, tbb_logfile_path=log_file) as driver:
-            driver.load_url_ensure(cm.CHECK_TPO_URL)
-
-        log_txt = ut.read_file(log_file)
-        # make sure we find the expected strings in the log
-        self.assertIn("torbutton@torproject.org", log_txt)
-        self.assertIn("addons.manager", log_txt)
-        if exists(log_file):
-            remove(log_file)
-
     def test_temp_tor_data_dir(self):
         """If we use a temporary directory as tor_data_dir,
-        tor datadir in TBB should stay unchanged.
+        tor datadir in TBB should remain unchanged.
         """
+
         tmp_dir = tempfile.mkdtemp()
         tbb_tor_data_path = join(TBB_PATH, cm.DEFAULT_TOR_DATA_PATH)
         last_mod_time_before = ut.get_last_modified_of_dir(tbb_tor_data_path)
-        with TBDriverFixture(TBB_PATH, tor_data_dir=tmp_dir) as driver:
+        with TBDriverFixture(TBB_PATH,
+                             tor_cfg=cm.LAUNCH_NEW_TBB_TOR,
+                             tor_data_dir=tmp_dir) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL)
         last_mod_time_after = ut.get_last_modified_of_dir(tbb_tor_data_path)
         self.assertEqual(last_mod_time_before, last_mod_time_after)
 
     def test_non_temp_tor_data_dir(self):
-        """Tor data dir in TBB should change if we don't use tor_data_dir."""
+        """Tor data dir in TBB should be modified if we don't use a temporary
+        tor_data_dir.
+        """
+
         tbb_tor_data_path = join(TBB_PATH, cm.DEFAULT_TOR_DATA_PATH)
         last_mod_time_before = ut.get_last_modified_of_dir(tbb_tor_data_path)
-        with TBDriverFixture(TBB_PATH) as driver:
+        with TBDriverFixture(TBB_PATH,
+                             tor_cfg=cm.LAUNCH_NEW_TBB_TOR) as driver:
             driver.load_url_ensure(cm.CHECK_TPO_URL)
         last_mod_time_after = ut.get_last_modified_of_dir(tbb_tor_data_path)
         self.assertNotEqual(last_mod_time_before, last_mod_time_after)
-
-
-class TBSecuritySlider(unittest.TestCase):
-
-    def test_security_slider_settings_hi(self):
-        """Setting `High` should disable JavaScript."""
-        with TBDriverFixture(TBB_PATH,
-                             pref_dict={SEC_SLIDER_PREF: 1}) as driver:
-            if not driver.supports_sec_slider:
-                pytest.skip("Security slider is not supported")
-            driver.load_url_ensure(cm.CHECK_TPO_URL)
-            try:
-                driver.find_element_by("JavaScript is enabled.",
-                                       find_by=By.LINK_TEXT, timeout=5)
-                self.fail("Security slider should disable JavaScript")
-            except (NoSuchElementException, TimeoutException):
-                pass
-
-    def test_security_slider_settings_low_mid(self):
-        # TODO: test other features to distinguish between levels
-        for sec_slider_setting in [2, 3, 4]:
-            slider_dict = {SEC_SLIDER_PREF: sec_slider_setting}
-            # 2: medium-high, 3: medium-low, 4: low (default)
-            with TBDriverFixture(TBB_PATH, pref_dict=slider_dict) as driver:
-                if not driver.supports_sec_slider:
-                    pytest.skip("Security slider is not supported")
-                driver.load_url_ensure(cm.CHECK_TPO_URL)
-                driver.find_element_by("JavaScript is enabled.",
-                                       find_by=By.LINK_TEXT, timeout=5)
-
-
-class TBDriverTestAssumptions(unittest.TestCase):
-    """Tests for some assumptions we use in the above tests."""
-    def test_https_everywhere_disabled(self):
-        """Make sure the HTTP->HTTPS redirection in the
-        test_httpseverywhere test is due to HTTPSEverywhere -
-        not because the site is forwarding to HTTPS by default.
-        """
-        disable_HE_pref = {"extensions.https_everywhere.globalEnabled": False}
-        with TBDriverFixture(TBB_PATH, pref_dict=disable_HE_pref) as driver:
-            driver.load_url_ensure(TEST_HTTP_URL, 1)
-            err_msg = "Test should be updated to use a site that doesn't \
-                auto-forward HTTP to HTTPS. %s " % driver.current_url
-            self.failIfEqual(driver.current_url, TEST_HTTPS_URL, err_msg)
-            self.assertEqual(driver.current_url, TEST_HTTP_URL,
-                             "Can't load the test page")
-
-    def test_noscript_webgl_enabled(self):
-        """Make sure that when we disable NoScript's WebGL blocking,
-        WebGL becomes available. This is to the test method we
-        use in test_noscript is sane.
-        """
-        disable_NS_webgl_pref = {"noscript.forbidWebGL": False}
-        with TBDriverFixture(TBB_PATH,
-                             pref_dict=disable_NS_webgl_pref) as driver:
-            driver.load_url_ensure(cm.CHECK_TPO_URL, wait_for_page_body=True)
-            webgl_support = driver.execute_script(WEBGL_CHECK_JS)
-            self.assertIsNotNone(webgl_support)
-            self.assertIn("activeTexture", webgl_support)
-            self.assertIn("getSupportedExtensions", webgl_support)

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -11,7 +11,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.utils import is_connectable
 
-from tbselenium.exceptions import TBDriverPathError, TBDriverPortError
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
 from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
@@ -27,9 +26,6 @@ WEBGL_CHECK_JS = "var cvs = document.createElement('canvas');\
 # https://gitweb.torproject.org/boklm/tor-browser-bundle-testsuite.git/tree/marionette/tor_browser_tests/test_https-everywhere.py#n18
 TEST_HTTP_URL = "http://www.freedomboxfoundation.org/thanks/"
 TEST_HTTPS_URL = "https://www.freedomboxfoundation.org/thanks/"
-
-MISSING_DIR = "_no_such_directory_"
-MISSING_FILE = "_no_such_file_"
 
 SEC_SLIDER_PREF = "extensions.torbutton.security_slider"
 
@@ -94,61 +90,6 @@ class TBDriverTest(unittest.TestCase):
                     break  # Found the loaded library in the memory map
             else:
                 self.fail("Can't find the loaded lib: %s" % (xul_lib_path))
-
-
-class TBDriverFailTest(unittest.TestCase):
-
-    def test_should_raise_for_missing_paths(self):
-        with self.assertRaises(TBDriverPathError) as exc:
-            TBDriverFixture()
-        exc_msg = exc.exception
-        self.assertEqual(str(exc_msg),
-                         "Either TBB path or Firefox profile and binary path "
-                         "should be provided ")
-
-    def test_should_raise_for_missing_tbb_path(self):
-        with self.assertRaises(TBDriverPathError) as exc:
-            TBDriverFixture(tbb_path=MISSING_DIR)
-        exc_msg = exc.exception
-        self.assertEqual(str(exc_msg),
-                         "TBB path is not a directory %s" % MISSING_DIR)
-
-    def test_should_raise_for_missing_fx_binary(self):
-        temp_dir = tempfile.mkdtemp()
-        with self.assertRaises(TBDriverPathError) as exc:
-            TBDriverFixture(tbb_fx_binary_path=MISSING_FILE,
-                            tbb_profile_path=temp_dir)
-        exc_msg = exc.exception
-        self.assertEqual(str(exc_msg),
-                         "Invalid Firefox binary %s" % MISSING_FILE)
-
-    def test_should_raise_for_missing_fx_profile(self):
-        _, temp_file = tempfile.mkstemp()
-        with self.assertRaises(TBDriverPathError) as exc:
-            TBDriverFixture(tbb_fx_binary_path=temp_file,
-                            tbb_profile_path=MISSING_DIR)
-        exc_msg = exc.exception
-        self.assertEqual(str(exc_msg),
-                         "Invalid Firefox profile dir %s" % MISSING_DIR)
-
-    def test_should_raise_for_invalid_pref_dict(self):
-        with self.assertRaises(AttributeError):
-            TBDriverFixture(TBB_PATH, pref_dict="foo")
-        with self.assertRaises(AttributeError):
-            TBDriverFixture(TBB_PATH, pref_dict=[1, 2])
-        with self.assertRaises(AttributeError):
-            TBDriverFixture(TBB_PATH, pref_dict=(1, 2))
-
-    def test_should_fail_launching_tor_on_custom_socks_port(self):
-        with self.assertRaises(TBDriverPortError):
-            TBDriverFixture(TBB_PATH, socks_port=10001,
-                            tor_cfg=cm.LAUNCH_NEW_TBB_TOR)
-
-    def test_should_not_load_with_wrong_sys_socks_port(self):
-        with TBDriverFixture(TBB_PATH, socks_port=9999,
-                             tor_cfg=cm.USE_RUNNING_TOR) as driver:
-            driver.load_url(cm.CHECK_TPO_URL)
-            self.assertTrue(driver.is_connection_error_page)
 
 
 class ScreenshotTest(unittest.TestCase):


### PR DESCRIPTION
Refactor test code, divide test_tbdriver into smaller modules

Better clean up if Tor connection fails.

Fix exception handling error for the Stem test.

Change default test behavior to use running system Tor.
This speeds up the test and make them more resilient
against (TBB) Tor bootstrap failures.

Add a test for Hidden Service access.
Run py.test with -v (verbose)