### PR TITLE
Cache TBB downloads on Travis, remove external timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ install:
   - pip install -r requirements-travis.txt
   - sudo apt-get -qq install tor
   - easy_install .
-  - tarball=`echo $VERSION_ARCH |cut -d'/' -f 2`
-  - wget https://archive.torproject.org/tor-package-archive/torbrowser/$VERSION_ARCH
+  - tarball=`echo ${VERSION_ARCH} |cut -d'/' -f 2`
+  - wget https://archive.torproject.org/tor-package-archive/torbrowser/${VERSION_ARCH}
   - tar -xf $tarball -C $HOME
   - locale=`echo $tarball |cut -d'_' -f 2 | cut -d'.' -f 1`
-  - export TBB_PATH=$HOME/tor-browser_$locale
+  - export TBB_PATH=${HOME}/tor-browser_$locale
 before_script:
   - cd tbselenium/test
 script: travis_retry py.test -s -v --cov=tbselenium --cov-report term-missing --durations=10

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: linux
 dist: trusty
 cache:
   directories:
-  - $HOME/download
+  - ${HOME}/download
 env:
   matrix:
     - TRAVIS_EXTRA_JOB_WORKAROUND=true
@@ -37,9 +37,9 @@ install:
   - pip install -r requirements-travis.txt
   - easy_install .
   - tarball=`echo ${VERSION_ARCH} |cut -d'/' -f 2`
-  - mkdir -p $HOME/download
-  - wget -N -P $HOME/download https://archive.torproject.org/tor-package-archive/torbrowser/${VERSION_ARCH}
-  - tar -xf $HOME/download/$tarball -C $HOME
+  - mkdir -p ${HOME}/download
+  - wget -N -P ${HOME}/download https://archive.torproject.org/tor-package-archive/torbrowser/${VERSION_ARCH}
+  - tar -xf ${HOME}/download/$tarball -C $HOME
   - locale=`echo $tarball |cut -d'_' -f 2 | cut -d'.' -f 1`
   - export TBB_PATH=${HOME}/tor-browser_$locale
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-sudo: required
+sudo: false
 language: python
 os: linux
 dist: trusty
+cache:
+  directories:
+  - $HOME/download
 env:
   matrix:
     - TRAVIS_EXTRA_JOB_WORKAROUND=true
@@ -32,11 +35,11 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 install:
   - pip install -r requirements-travis.txt
-  - sudo apt-get -qq install tor
   - easy_install .
   - tarball=`echo ${VERSION_ARCH} |cut -d'/' -f 2`
-  - wget https://archive.torproject.org/tor-package-archive/torbrowser/${VERSION_ARCH}
-  - tar -xf $tarball -C $HOME
+  - mkdir -p $HOME/download
+  - wget -N -P $HOME/download https://archive.torproject.org/tor-package-archive/torbrowser/${VERSION_ARCH}
+  - tar -xf $HOME/download/$tarball -C $HOME
   - locale=`echo $tarball |cut -d'_' -f 2 | cut -d'.' -f 1`
   - export TBB_PATH=${HOME}/tor-browser_$locale
 before_script:

--- a/tbselenium/common.py
+++ b/tbselenium/common.py
@@ -29,6 +29,10 @@ DEFAULT_CONTROL_PORT = 9051
 TBB_SOCKS_PORT = 9150
 TBB_CONTROL_PORT = 9151
 
+# pick 9250, 9251 to avoid conflict
+STEM_SOCKS_PORT = 9250
+STEM_CONTROL_PORT = 9251
+
 KNOWN_SOCKS_PORTS = [DEFAULT_SOCKS_PORT, TBB_SOCKS_PORT]
 PORT_BAN_PREFS = ["extensions.torbutton.banned_ports",
                   "network.security.ports.banned"]

--- a/tbselenium/exceptions.py
+++ b/tbselenium/exceptions.py
@@ -17,3 +17,11 @@ class TBDriverConfigError(Exception):
 
 class TimeExceededError(Exception):
     pass
+
+
+class TorBrowserDriverInitError(Exception):
+    pass
+
+
+class StemLaunchError(Exception):
+    pass

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -55,6 +55,7 @@ class TorBrowserDriver(FirefoxDriver):
                                                capabilities=self.capabilities,
                                                timeout=cm.TB_INIT_TIMEOUT)
         self.is_running = True
+        sleep(1)
 
     def init_socks_port(self, tor_cfg, socks_port):
         """Check SOCKS port and Tor config inputs."""

--- a/tbselenium/test/conftest.py
+++ b/tbselenium/test/conftest.py
@@ -1,52 +1,25 @@
 from os import environ
 import tempfile
-from os.path import join, dirname
-from tbselenium import common as cm
-from tbselenium.test import TBB_PATH
-try:
-    from stem.process import launch_tor_with_config
-except ImportError:
-    pass
-
-try:
-    from pyvirtualdisplay import Display
-except ImportError:  # we don't need/install it when running CI tests
-    pass
-
-# Default size for the virtual display
-DEFAULT_XVFB_WIN_W = 1280
-DEFAULT_XVFB_WIN_H = 800
+from tbselenium.utils import start_xvfb, stop_xvfb
+from tbselenium.test.fixtures import launch_tbb_tor_with_stem_fixture
+import tbselenium.common as cm
 
 test_conf = {}
 
 
-def start_xvfb(win_width=DEFAULT_XVFB_WIN_W,
-               win_height=DEFAULT_XVFB_WIN_H):
-    xvfb_display = Display(visible=0, size=(win_width, win_height))
-    xvfb_display.start()
-    return xvfb_display
-
-
-def stop_xvfb(xvfb_display):
-    if xvfb_display:
-        xvfb_display.stop()
-
-
-def start_tor_with_default_ports():
-    custom_tor_binary = join(TBB_PATH, cm.DEFAULT_TOR_BINARY_PATH)
-    environ["LD_LIBRARY_PATH"] = dirname(custom_tor_binary)
+def launch_tor():
     temp_data_dir = tempfile.mkdtemp()
     torrc = {'ControlPort': str(cm.DEFAULT_CONTROL_PORT),
              'SOCKSPort': str(cm.DEFAULT_SOCKS_PORT),
              'DataDirectory': temp_data_dir}
-    return launch_tor_with_config(config=torrc, tor_cmd=custom_tor_binary)
+    launch_tbb_tor_with_stem_fixture(torrc=torrc)
 
 
 def pytest_sessionstart(session):
     if "TRAVIS" not in environ and "NO_XVFB" not in environ:
         test_conf["xvfb_display"] = start_xvfb()
     if "TRAVIS" in environ:
-        test_conf["tor_process"] = start_tor_with_default_ports()
+        test_conf["tor_process"] = launch_tor()
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tbselenium/test/conftest.py
+++ b/tbselenium/test/conftest.py
@@ -1,4 +1,13 @@
 from os import environ
+import tempfile
+from os.path import join, dirname
+from tbselenium import common as cm
+from tbselenium.test import TBB_PATH
+try:
+    from stem.process import launch_tor_with_config
+except ImportError:
+    pass
+
 try:
     from pyvirtualdisplay import Display
 except ImportError:  # we don't need/install it when running CI tests
@@ -8,7 +17,7 @@ except ImportError:  # we don't need/install it when running CI tests
 DEFAULT_XVFB_WIN_W = 1280
 DEFAULT_XVFB_WIN_H = 800
 
-test_conf = {"xvfb_display": None}
+test_conf = {}
 
 
 def start_xvfb(win_width=DEFAULT_XVFB_WIN_W,
@@ -23,12 +32,28 @@ def stop_xvfb(xvfb_display):
         xvfb_display.stop()
 
 
+def start_tor_with_default_ports():
+    custom_tor_binary = join(TBB_PATH, cm.DEFAULT_TOR_BINARY_PATH)
+    environ["LD_LIBRARY_PATH"] = dirname(custom_tor_binary)
+    temp_data_dir = tempfile.mkdtemp()
+    torrc = {'ControlPort': str(cm.DEFAULT_CONTROL_PORT),
+             'SOCKSPort': str(cm.DEFAULT_SOCKS_PORT),
+             'DataDirectory': temp_data_dir}
+    return launch_tor_with_config(config=torrc, tor_cmd=custom_tor_binary)
+
+
 def pytest_sessionstart(session):
     if "TRAVIS" not in environ and "NO_XVFB" not in environ:
         test_conf["xvfb_display"] = start_xvfb()
+    if "TRAVIS" in environ:
+        test_conf["tor_process"] = start_tor_with_default_ports()
 
 
 def pytest_sessionfinish(session, exitstatus):
-    xvfb_display = test_conf["xvfb_display"]
+    xvfb_display = test_conf.get("xvfb_display")
+    tor_process = test_conf.get("tor_process")
     if xvfb_display:
         stop_xvfb(xvfb_display)
+
+    if tor_process:
+        tor_process.kill()

--- a/tbselenium/test/fixtures.py
+++ b/tbselenium/test/fixtures.py
@@ -61,12 +61,11 @@ class TorBrowserDriverFixture(TorBrowserDriver):
         last_err = RuntimeError("Unknown error")
         for tries in range(MAX_FIXTURE_TRIES):
             try:
-                timeout(LOAD_PAGE_TIMEOUT)
                 self.load_url(*args, **kwargs)
                 if self.current_url != "about:newtab" and \
                         not self.is_connection_error_page:
                     break
-            except (TimeoutException, TimeExceededError,
+            except (TimeoutException,
                     CannotSendRequest) as last_err:
                 print ("\nload_url timed out.  Attempt %s %s" %
                        ((tries + 1), last_err))

--- a/tbselenium/test/fixtures.py
+++ b/tbselenium/test/fixtures.py
@@ -1,6 +1,7 @@
 from tbselenium.tbdriver import TorBrowserDriver
 import tbselenium.common as cm
 from tbselenium.exceptions import StemLaunchError, TorBrowserDriverInitError
+from tbselenium.utils import launch_tbb_tor_with_stem
 from selenium.common.exceptions import TimeoutException, WebDriverException
 from selenium.webdriver.common.utils import is_connectable
 
@@ -8,26 +9,22 @@ try:
     from httplib import CannotSendRequest
 except ImportError:
     from http.client import CannotSendRequest
-try:
-    from stem.process import launch_tor_with_config
-except ImportError as err:
-    pass
+
 
 MAX_FIXTURE_TRIES = 3
 
 
-class TorBrowserDriverFixture(TorBrowserDriver):
+class TBDriverFixture(TorBrowserDriver):
     """Extend TorBrowserDriver to have fixtures for tests."""
     def __init__(self, *args, **kwargs):
         self.change_default_tor_cfg(kwargs)
         for tries in range(MAX_FIXTURE_TRIES):
             try:
-                return super(TorBrowserDriverFixture, self).__init__(*args,
-                                                                     **kwargs)
+                return super(TBDriverFixture, self).__init__(*args, **kwargs)
             except (TimeoutException, WebDriverException) as last_err:
                 print ("\nTBDriver init timed out. Attempt %s %s" %
                        ((tries + 1), last_err))
-                super(TorBrowserDriverFixture, self).quit()  # clean up
+                super(TBDriverFixture, self).quit()  # clean up
                 continue
         else:
             raise TorBrowserDriverInitError("Cannot initialize")
@@ -63,14 +60,14 @@ class TorBrowserDriverFixture(TorBrowserDriver):
             raise WebDriverException("Can't load the page")
 
 
-def launch_tor_with_config_fixture(*args, **kwargs):
+def launch_tbb_tor_with_stem_fixture(*args, **kwargs):
     for tries in range(MAX_FIXTURE_TRIES):
         try:
-            return launch_tor_with_config(*args, **kwargs)
+            return launch_tbb_tor_with_stem(*args, **kwargs)
         except OSError as last_err:
             print ("\nlaunch_tor try %s %s" % ((tries + 1), last_err))
             if "timeout without success" in str(last_err):
                 continue
-            else:
+            else:  # we don't want to retry if this is not a timeout
                 raise
     raise StemLaunchError("Cannot start Tor")

--- a/tbselenium/test/fixtures.py
+++ b/tbselenium/test/fixtures.py
@@ -1,8 +1,6 @@
-import signal
 from tbselenium.tbdriver import TorBrowserDriver
 import tbselenium.common as cm
-from tbselenium.exceptions import (TimeExceededError, StemLaunchError,
-                                   TorBrowserDriverInitError)
+from tbselenium.exceptions import StemLaunchError, TorBrowserDriverInitError
 from selenium.common.exceptions import TimeoutException, WebDriverException
 from selenium.webdriver.common.utils import is_connectable
 
@@ -16,10 +14,6 @@ except ImportError as err:
     pass
 
 MAX_FIXTURE_TRIES = 3
-EXTERNAL_TIMEOUT_GRACE = 5  # only fire if the internal timeout fails
-LAUNCH_TOR_TIMEOUT = 30 + EXTERNAL_TIMEOUT_GRACE
-LOAD_PAGE_TIMEOUT = 60
-TB_INIT_EXT_TIMEOUT = cm.TB_INIT_TIMEOUT + EXTERNAL_TIMEOUT_GRACE
 
 
 class TorBrowserDriverFixture(TorBrowserDriver):
@@ -80,20 +74,3 @@ def launch_tor_with_config_fixture(*args, **kwargs):
             else:
                 raise
     raise StemLaunchError("Cannot start Tor")
-
-
-# We only experience timeouts on Travis CI
-def raise_signal(signum, frame):
-    """Raise an exception to signal timeout."""
-    raise TimeExceededError("Timed out")
-
-
-def timeout(duration):
-    """Timeout after given duration. Linux only."""
-    signal.signal(signal.SIGALRM, raise_signal)
-    signal.alarm(duration)  # alarm after X seconds
-
-
-def cancel_timeout():
-    """Cancel the running alarm."""
-    signal.alarm(0)

--- a/tbselenium/test/test_addons.py
+++ b/tbselenium/test/test_addons.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -42,6 +43,7 @@ class NoScriptTest(unittest.TestCase):
     WEBGL_CHECK_JS = "var cvs = document.createElement('canvas');\
                     return cvs.getContext('experimental-webgl');"
 
+    @pytest.mark.skipif(cm.TRAVIS, reason="CI doesn't support WebGL")
     def test_noscript(self):
         """NoScript should disable WebGL."""
         with TBDriverFixture(TBB_PATH) as driver:
@@ -50,6 +52,7 @@ class NoScriptTest(unittest.TestCase):
             webgl_support = driver.execute_script(self.WEBGL_CHECK_JS)
             self.assertIsNone(webgl_support)
 
+    @pytest.mark.skipif(cm.TRAVIS, reason="CI doesn't support WebGL")
     def test_noscript_webgl_enabled(self):
         """Make sure that when we disable NoScript's WebGL blocking,
         WebGL becomes available. This is to the test method we

--- a/tbselenium/test/test_addons.py
+++ b/tbselenium/test/test_addons.py
@@ -6,7 +6,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium.test.fixtures import TBDriverFixture
 
 
 class HTTPSEverywhereTest(unittest.TestCase):

--- a/tbselenium/test/test_browser.py
+++ b/tbselenium/test/test_browser.py
@@ -2,7 +2,7 @@ import pytest
 import sys
 import unittest
 import tempfile
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium.test.fixtures import TBDriverFixture
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
 import tbselenium.utils as ut

--- a/tbselenium/test/test_bundled_fonts.py
+++ b/tbselenium/test/test_bundled_fonts.py
@@ -7,7 +7,7 @@ from os import environ
 from os.path import join
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium.test.fixtures import TBDriverFixture
 import tbselenium.utils as ut
 
 

--- a/tbselenium/test/test_exceptions.py
+++ b/tbselenium/test/test_exceptions.py
@@ -2,7 +2,7 @@ import unittest
 import tempfile
 from tbselenium.exceptions import TBDriverPathError, TBDriverPortError
 from tbselenium.test import TBB_PATH
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium.test.fixtures import TBDriverFixture
 from tbselenium import common as cm
 
 MISSING_DIR = "_no_such_directory_"

--- a/tbselenium/test/test_screenshot.py
+++ b/tbselenium/test/test_screenshot.py
@@ -3,7 +3,7 @@ import tempfile
 from os import remove
 from os.path import getsize, exists
 
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium.test.fixtures import TBDriverFixture
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
 

--- a/tbselenium/test/test_security_slider.py
+++ b/tbselenium/test/test_security_slider.py
@@ -4,7 +4,7 @@ import pytest
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
 
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium.test.fixtures import TBDriverFixture
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
 

--- a/tbselenium/test/test_stem.py
+++ b/tbselenium/test/test_stem.py
@@ -1,43 +1,35 @@
 import unittest
 import pytest
-import tempfile
-from os import environ
-from os.path import join, dirname
-
-from tbselenium.test.fixtures import launch_tor_with_config_fixture
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium.test.fixtures import TBDriverFixture
+from tbselenium.test.fixtures import launch_tbb_tor_with_stem_fixture
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
+
+try:
+    from stem.control import Controller
+except ImportError as err:
+    pytest.skip("Can't import Stem. Skipping test: %s" % err)
 
 
 class TBStemTest(unittest.TestCase):
 
+    def tearDown(self):
+        if self.tor_process:
+            self.tor_process.kill()
+
     def test_running_with_stem(self):
-        """We should be able to run with a tor process started with Stem."""
-        try:
-            from stem.control import Controller
-        except ImportError as err:
-            pytest.skip("Can't import Stem. Skipping test: %s" % err)
-        custom_tor_binary = join(TBB_PATH, cm.DEFAULT_TOR_BINARY_PATH)
-        environ["LD_LIBRARY_PATH"] = dirname(custom_tor_binary)
-        # any port would do, pick 9250, 9251 to avoid conflict
-        socks_port = 9250
-        control_port = 9251
-        temp_data_dir = tempfile.mkdtemp()
-        torrc = {'ControlPort': str(control_port),
-                 'SOCKSPort': str(socks_port),
-                 'DataDirectory': temp_data_dir}
-        tor_process = launch_tor_with_config_fixture(config=torrc,
-                                                     tor_cmd=custom_tor_binary)
-        with Controller.from_port(port=control_port) as controller:
+        self.tor_process = launch_tbb_tor_with_stem_fixture()
+        with Controller.from_port(port=cm.STEM_CONTROL_PORT) as controller:
             controller.authenticate()
-            with TBDriverFixture(TBB_PATH, tor_cfg=cm.USE_RUNNING_TOR,
-                                 socks_port=socks_port) as driver:
+
+            with TBDriverFixture(TBB_PATH,
+                                 tor_cfg=cm.USE_RUNNING_TOR,
+                                 socks_port=cm.STEM_SOCKS_PORT) as driver:
+
                 driver.load_url_ensure(cm.CHECK_TPO_URL)
                 driver.find_element_by("h1.on")
-
-        if tor_process:
-            tor_process.kill()
+                ccts = controller.get_circuits()
+                self.assertGreater(len(ccts), 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tbselenium/test/test_tbdriver.py
+++ b/tbselenium/test/test_tbdriver.py
@@ -7,7 +7,7 @@ from selenium.webdriver.common.utils import is_connectable
 
 from tbselenium import common as cm
 from tbselenium.test import TBB_PATH
-from tbselenium.test.fixtures import TorBrowserDriverFixture as TBDriverFixture
+from tbselenium.test.fixtures import TBDriverFixture
 import tbselenium.utils as ut
 
 


### PR DESCRIPTION
Start running test on container-based infrastructure.

Use Stem to start a Tor process on CI.

Remove external timeout for the fixtures.

Disable WebGL tests on CI.

Use curly braces for environment variables in Travis config.

Add one second sleep after TorBrowserDriver initialization.
This prevents cases where the driver doesn't respond to
commands.