### PR TITLE
Don't download TBB tarball if it's already in the cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,5 @@ install:
   - tar -xf ${DOWNLOAD_DIR}/$tarball -C $HOME
   - export TBB_PATH=${HOME}/tor-browser_$locale
 before_script:
-  - cd tbselenium/test
-script: travis_retry py.test -s -v --cov=tbselenium --cov-report term-missing --durations=10
+  - cd tbselenium
+script: travis_retry py.test -s -v --cov=tbselenium --cov-report term-missing --durations=10 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - tarball=`echo ${VERSION_ARCH} |cut -d'/' -f 2`
   - locale=`echo $tarball |cut -d'_' -f 2 | cut -d'.' -f 1`
   - mkdir -p ${DOWNLOAD_DIR}
-  - [ ! -e "${DOWNLOAD_DIR}/$tarball" ] && wget -P ${DOWNLOAD_DIR} ${TBB_ARCHIVE_URL}/${VERSION_ARCH}
+  - "[ ! -e ${DOWNLOAD_DIR}/$tarball ] && wget -P ${DOWNLOAD_DIR} ${TBB_ARCHIVE_URL}/${VERSION_ARCH}"
   - tar -xf ${DOWNLOAD_DIR}/$tarball -C $HOME
   - export TBB_PATH=${HOME}/tor-browser_$locale
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ sudo: false
 language: python
 os: linux
 dist: trusty
-cache:
-  directories:
-  - ${HOME}/download
 env:
+  global:
+    - DOWNLOAD_DIR=${HOME}/download
+    - TBB_ARCHIVE_URL=https://archive.torproject.org/tor-package-archive/torbrowser
   matrix:
     - TRAVIS_EXTRA_JOB_WORKAROUND=true
+cache:
+  directories:
+  - ${DOWNLOAD_DIR}
 matrix:
   include:
     - python: "2.7"
@@ -37,10 +40,10 @@ install:
   - pip install -r requirements-travis.txt
   - easy_install .
   - tarball=`echo ${VERSION_ARCH} |cut -d'/' -f 2`
-  - mkdir -p ${HOME}/download
-  - wget -N -P ${HOME}/download https://archive.torproject.org/tor-package-archive/torbrowser/${VERSION_ARCH}
-  - tar -xf ${HOME}/download/$tarball -C $HOME
   - locale=`echo $tarball |cut -d'_' -f 2 | cut -d'.' -f 1`
+  - mkdir -p ${DOWNLOAD_DIR}
+  - [ ! -e "${DOWNLOAD_DIR}/$tarball" ] && wget -P ${DOWNLOAD_DIR} ${TBB_ARCHIVE_URL}/${VERSION_ARCH}
+  - tar -xf ${DOWNLOAD_DIR}/$tarball -C $HOME
   - export TBB_PATH=${HOME}/tor-browser_$locale
 before_script:
   - cd tbselenium/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - tarball=`echo ${VERSION_ARCH} |cut -d'/' -f 2`
   - locale=`echo $tarball |cut -d'_' -f 2 | cut -d'.' -f 1`
   - mkdir -p ${DOWNLOAD_DIR}
-  - "[ ! -e ${DOWNLOAD_DIR}/$tarball ] && wget -P ${DOWNLOAD_DIR} ${TBB_ARCHIVE_URL}/${VERSION_ARCH}"
+  - "[ ! -f ${DOWNLOAD_DIR}/$tarball ] && wget -P ${DOWNLOAD_DIR} ${TBB_ARCHIVE_URL}/${VERSION_ARCH}"
   - tar -xf ${DOWNLOAD_DIR}/$tarball -C $HOME
   - export TBB_PATH=${HOME}/tor-browser_$locale
 before_script:

--- a/tbselenium/.coveragerc
+++ b/tbselenium/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    test/*


### PR DESCRIPTION
Don't download TBB tarball if it's already in Travis cache.

Exclude test files from coverage tests.