### PR TITLE
Add optional control_port argument to TorBrowserDriver's init

### DIFF
--- a/examples/stem_adv.py
+++ b/examples/stem_adv.py
@@ -44,6 +44,7 @@ def launch_tb_with_custom_stem(tbb_dir):
     with Controller.from_port(port=control_port) as controller:
         controller.authenticate()
         with TorBrowserDriver(tbb_dir, socks_port=socks_port,
+                              control_port=control_port,
                               tor_cfg=cm.USE_RUNNING_TOR) as driver:
             driver.load_url("https://check.torproject.org", wait_on_page=3)
             print(driver.find_element_by("h1.on").text)

--- a/tbselenium/test/test_exceptions.py
+++ b/tbselenium/test/test_exceptions.py
@@ -58,13 +58,9 @@ class TBDriverExceptions(unittest.TestCase):
             TorBrowserDriver(TBB_PATH, pref_dict=(1, 2))
 
     def test_should_fail_launching_tbb_tor_on_custom_socks_port(self):
-        with self.assertRaises(TBDriverPortError) as exc:
+        with self.assertRaises(TBDriverPortError):
             TorBrowserDriver(TBB_PATH, socks_port=free_port(),
                              tor_cfg=cm.LAUNCH_NEW_TBB_TOR)
-        self.assertEqual(str(exc.exception),
-                         "Can only launch Tor on TBB's default"
-                         "port (9150). Use Stem for launching"
-                         "Tor on a custom SOCKS port")
 
     def test_should_fail_launching_tbb_tor_on_used_port(self):
         if not is_busy(cm.DEFAULT_SOCKS_PORT):


### PR DESCRIPTION
Get only the modified time of the top director (not recursively).