### PR TITLE
Kill tor processes before running a test.

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+killall tor
 mkdir -p ${DOWNLOAD_DIR}
 echo $VERSION_ARCH
 echo ${TBB_ARCHIVE_URL}/${VERSION_ARCH}


### PR DESCRIPTION
When the CI tests are rerun due to an error, port 9150 remains in use, e.g.
https://travis-ci.org/webfp/tor-browser-selenium/jobs/152723582#L519

This should be due to remaining Tor processes from the previous test run.

This commit kills all Tor process before starting a new CI test run.