### PR TITLE
Include test module in tbselenium package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ setup(
     name="tbselenium",
     description="Tor Browser automation with Selenium",
     keywords=["tor", "selenium", "tor browser"],
-    version=0.1,
+    version=0.2,
     url = 'https://github.com/webfp/tor-browser-selenium',
-    packages=["tbselenium"],
+    packages=["tbselenium", "tbselenium.test"],
     install_requires=[
         "selenium>=2.45.0,<3"
     ]


### PR DESCRIPTION
Test module was not included in the distributed package,
e.g. the one available on PyPI.

Update the package version to 0.2.

Fixes #75.