### PR TITLE
Add an option to use a different default bridge

### DIFF
--- a/examples/bridge.py
+++ b/examples/bridge.py
@@ -1,18 +1,17 @@
 from argparse import ArgumentParser
 from tbselenium.tbdriver import TorBrowserDriver
 from time import sleep
+# Usage: python bridge.py /path/to/tor-browser-bundle bridge_type
+# bridge_type is one of: obfs3, obfs4, fte, meek-amazon, meek-azure 
 
-BRIDGE_TYPE_PREF = "extensions.torlauncher.default_bridge_type"
-
-
-def visit(tbb_dir):
+def visit_using_bridge(tbb_dir, bridge_type="meek-amazon"):
     url = "https://check.torproject.org"
     with TorBrowserDriver(
-        tbb_dir, pref_dict={BRIDGE_TYPE_PREF: "meek-amazon"}) as driver:
+        tbb_dir, default_bridge_type=bridge_type) as driver:
         driver.load_url(url)
         print driver.find_element_by("h1.on").text  # status text
-        # Leave some time to check the Tor circuit interface to
-        sleep(10)  # verify that the bridge is really used.
+        sleep(10)  # To verify that the bridge is indeed uses, go to
+        # Tor Network Settings dialog
          
 
 
@@ -20,8 +19,9 @@ def main():
     desc = "Visit check.torproject.org website using a Tor bridge"
     parser = ArgumentParser(description=desc)
     parser.add_argument('tbb_path')
+    parser.add_argument('bridge_type', nargs='?', default="meek-amazon")
     args = parser.parse_args()
-    visit(args.tbb_path)
+    visit_using_bridge(args.tbb_path, args.bridge_type)
 
 if __name__ == '__main__':
     main()

--- a/examples/bridge.py
+++ b/examples/bridge.py
@@ -1,0 +1,27 @@
+from argparse import ArgumentParser
+from tbselenium.tbdriver import TorBrowserDriver
+from time import sleep
+
+BRIDGE_TYPE_PREF = "extensions.torlauncher.default_bridge_type"
+
+
+def visit(tbb_dir):
+    url = "https://check.torproject.org"
+    with TorBrowserDriver(
+        tbb_dir, pref_dict={BRIDGE_TYPE_PREF: "meek-amazon"}) as driver:
+        driver.load_url(url)
+        print driver.find_element_by("h1.on").text  # status text
+        # Leave some time to check the Tor circuit interface to
+        sleep(10)  # verify that the bridge is really used.
+         
+
+
+def main():
+    desc = "Visit check.torproject.org website using a Tor bridge"
+    parser = ArgumentParser(description=desc)
+    parser.add_argument('tbb_path')
+    args = parser.parse_args()
+    visit(args.tbb_path)
+
+if __name__ == '__main__':
+    main()

--- a/tbselenium/tbdriver.py
+++ b/tbselenium/tbdriver.py
@@ -37,7 +37,8 @@ class TorBrowserDriver(FirefoxDriver):
                  socks_port=None,
                  control_port=None,
                  extensions=[],
-                 canvas_allowed_hosts=[]):
+                 canvas_allowed_hosts=[],
+                 default_bridge_type=""):
 
         self.tor_cfg = tor_cfg
         self.setup_tbb_paths(tbb_path, tbb_fx_binary_path,
@@ -47,7 +48,7 @@ class TorBrowserDriver(FirefoxDriver):
         add_canvas_permission(self.profile.path, self.canvas_allowed_hosts)
         self.install_extensions(extensions)
         self.init_ports(tor_cfg, socks_port, control_port)
-        self.init_prefs(pref_dict)
+        self.init_prefs(pref_dict, default_bridge_type)
         self.init_tb_version()
         self.setup_capabilities()
         self.export_env_vars()
@@ -204,7 +205,7 @@ class TorBrowserDriver(FirefoxDriver):
         set_pref('extensions.torlauncher.logmethod', 0)
         set_pref('extensions.torlauncher.prompt_at_startup', False)
 
-    def init_prefs(self, pref_dict):
+    def init_prefs(self, pref_dict, default_bridge_type):
         self.add_ports_to_fx_banned_ports(self.socks_port, self.control_port)
         set_pref = self.profile.set_preference
         set_pref('browser.startup.page', "0")
@@ -218,6 +219,12 @@ class TorBrowserDriver(FirefoxDriver):
         # following is only needed for TBB < 4.5a3 to add canvas permissions
         if self.canvas_allowed_hosts:
             set_pref('permissions.memory_only', False)
+        if default_bridge_type:
+            # to use a non-default bridge, overwrite the relevant pref, e.g.:
+            # extensions.torlauncher.default_bridge.meek-azure.1 = meek 0.0....
+            set_pref('extensions.torlauncher.default_bridge_type',
+                     default_bridge_type)
+
         set_pref('extensions.torbutton.prompted_language', True)
         # Configure Firefox to use Tor SOCKS proxy
         set_pref('network.proxy.socks_port', self.socks_port)

--- a/tbselenium/test/test_bridge.py
+++ b/tbselenium/test/test_bridge.py
@@ -1,0 +1,42 @@
+import unittest
+# from time import sleep
+
+from tbselenium import common as cm
+from tbselenium.test import TBB_PATH
+from tbselenium.test.fixtures import TBDriverFixture
+
+CONGRATS = "Congratulations. This browser is configured to use Tor."
+
+
+class TBDriverBridgeTest(unittest.TestCase):
+    def tearDown(self):
+        self.tb_driver.quit()
+    
+    def should_load_check_tpo_via_bridge(self, bridge_type):
+        self.tb_driver = TBDriverFixture(TBB_PATH,
+                                         default_bridge_type=bridge_type)
+        self.tb_driver.load_url_ensure(cm.CHECK_TPO_URL)
+        status = self.tb_driver.find_element_by("h1.on")
+        self.assertEqual(status.text, CONGRATS)
+        # sleep(0)  # the bridge type in use is manually verified by
+        # checking the Tor Network Settings dialog.
+        # We set a sleep of a few seconds and exported NO_XVFB=1 to do that manually.
+
+        # TODO: find a way to automatically verify the bridge in use
+        # This may be possible with geckodriver, since it can interact
+        # with chrome as well.
+    
+    def test_should_load_check_tpo_via_meek_amazon_bridge(self):
+        self.should_load_check_tpo_via_bridge("meek-amazon")
+
+    def test_should_load_check_tpo_via_meek_azure_bridge(self):
+        self.should_load_check_tpo_via_bridge("meek-azure")
+
+    def test_should_load_check_tpo_via_meek_obfs3_bridge(self):
+        self.should_load_check_tpo_via_bridge("obfs3")
+
+    def test_should_load_check_tpo_via_obfs4_bridge(self):
+        self.should_load_check_tpo_via_bridge("obfs4")
+
+    def test_should_load_check_tpo_via_fte_bridge(self):
+        self.should_load_check_tpo_via_bridge("fte")


### PR DESCRIPTION
Add a new argument called `default_bridge_type` to choose between several bridge types already shipped with TBB.

To use bridges that are not shipped with the Tor Browser Bundle, one still needs to set prefs.