### PR TITLE
Use pip instead of easy_install for installing tbselenium.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y tor
 install:
-  - pip install --ignore-installed -r requirements-travis.txt
-  - easy_install .
+  - pip install -r requirements-travis.txt
+  - pip install .
   - TARBALL=`echo ${VERSION_ARCH} |cut -d'/' -f 2`
   - . ./travis.sh
   - locale="_"`echo $TARBALL |cut -d'_' -f 2 | cut -d'.' -f 1`


### PR DESCRIPTION
This is to avoid `easy_install` errors such as this: https://travis-ci.org/webfp/tor-browser-selenium/jobs/311084038#L571

Remove the `ignore-installed` flag, which was added to address the same issue.