### PR TITLE
Add exe to firefox binary path

### DIFF
--- a/tbselenium/common.py
+++ b/tbselenium/common.py
@@ -5,7 +5,7 @@ from os import environ
 # Old TBB versions (V3.X or below) have different directory structures
 DEFAULT_TBB_BROWSER_DIR = 'Browser'
 DEFAULT_TBB_TORBROWSER_DIR = join('Browser', 'TorBrowser')
-DEFAULT_TBB_FX_BINARY_PATH = join('Browser', 'firefox')
+DEFAULT_TBB_FX_BINARY_PATH = join('Browser', 'firefox.exe')
 DEFAULT_TOR_BINARY_DIR = join(DEFAULT_TBB_TORBROWSER_DIR, 'Tor')
 DEFAULT_TOR_BINARY_PATH = join(DEFAULT_TOR_BINARY_DIR, 'tor')
 DEFAULT_TBB_DATA_DIR = join(DEFAULT_TBB_TORBROWSER_DIR, 'Data')


### PR DESCRIPTION
Added .exe to firefox binary path because otherwise it doesn't find a binary